### PR TITLE
docs: fix missing words and grammar

### DIFF
--- a/code/ratatui-json-editor-app/src/main.rs
+++ b/code/ratatui-json-editor-app/src/main.rs
@@ -39,7 +39,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     // create app and run it
     let mut app = App::new();
     let res = run_app(&mut terminal, &mut app);
-
     // ANCHOR_END: application_startup
 
     // ANCHOR: ending_boilerplate

--- a/src/content/docs/concepts/event-handling.md
+++ b/src/content/docs/concepts/event-handling.md
@@ -13,8 +13,10 @@ is the one that works for you and your current application.
 
 This is the simplest way to handle events because it handles all of the events as they appear. It is
 often simply a match on the results of `event::read()?` (in crossterm) on the different supported
-keys. Pros: This has the advantage of requiring no message passing, and allows the programmer to
-edit all of the possible keyboard events in one place.
+keys.
+
+Pros: This has the advantage of requiring no message passing, and allows the programmer to edit all
+of the possible keyboard events in one place.
 
 Cons: However, this particular way of handling events simply does not scale well. Because _all_
 events are handled in one place, you will be unable to split different groups of keybinds out into

--- a/src/content/docs/concepts/rendering/under-the-hood.md
+++ b/src/content/docs/concepts/rendering/under-the-hood.md
@@ -144,14 +144,14 @@ These methods allow any implementation of the `Widget` trait to write into diffe
 Every time your application calls `terminal.draw(|frame| ...)`, Ratatui passes into the closure a
 new instance of [`Frame`] which contains a mutable reference to an instance of `Buffer`. Ratatui
 widgets render to this intermediate buffer before any information is written to the terminal and any
-content rendered to a `Buffer` is only stored in `Buffer` that is attached to the frame during the
-`draw` call. This is in contrast to using a library like `crossterm` directly, where writing text to
-terminal can occur immediately.
+content rendered to a `Buffer` is only stored in the `Buffer` that is attached to the frame during
+the `draw` call. This is in contrast to using a library like `crossterm` directly, where writing
+text to terminal can occur immediately.
 
 :::note
 
 ANSI Escape sequences for color and style that are stored in the cell's string content are not
-rendered as the style information is stored separately in the cell. If your text has ANSI styling
+rendered, as the style information is stored separately in the cell. If your text has ANSI styling
 info, consider using the [`ansi-to-tui`](https://crates.io/crates/ansi-to-tui) crate to convert it
 to a `Text` value before rendering. You can learn more about the text related Ratatui features and
 displaying text [here](/recipes/render/display-text/).

--- a/src/content/docs/concepts/widgets.md
+++ b/src/content/docs/concepts/widgets.md
@@ -181,7 +181,7 @@ specified coordinates in the buffer.
 Widgets are not restricted to just calling methods on `Buffer`. They can also create and render
 other widgets within their `render` method. For example, instead of directly calling methods on
 `buf`, a Widget can create a `Line` widget with a vector of `Span`s, where the `Span` for the name
-is style. This `Line` widget can then be rendered within the Widget's `render` method.
+is styled. This `Line` widget can then be rendered within the Widget's `render` method.
 
 Here's the same greeting example using nested widgets:
 
@@ -200,8 +200,8 @@ impl Widget for GreetingWidget {
 }
 ```
 
-This approach allows for composing and and reusing widgets. For example, the `Line` widget can be
-used in other widgets or even in other parts of the application. Additionally, it allows for easier
+This approach allows for composing and reusing widgets. For example, the `Line` widget can be used
+in other widgets or even in other parts of the application. Additionally, it allows for easier
 testing and maintenance of widgets as the code related to rendering is organized in a consistent
 place (the `impl Widget` blocks).
 

--- a/src/content/docs/installation/index.md
+++ b/src/content/docs/installation/index.md
@@ -40,9 +40,9 @@ You can learn more about available widgets from the
 
 :::
 
-By default, `ratatui` enables the `crossterm`, but it's possible to alternatively use `termion`, or
-`termwiz` instead by enabling the appropriate feature and disabling the default features. See
-[Backend] for more information.
+By default, `ratatui` enables the `crossterm` feature, but it's possible to alternatively use
+`termion`, or `termwiz` instead by enabling the appropriate feature and disabling the default
+features. See [Backend] for more information.
 
 For Termion:
 

--- a/src/content/docs/tutorials/counter-app/basic-app.md
+++ b/src/content/docs/tutorials/counter-app/basic-app.md
@@ -140,11 +140,12 @@ impl App {
 
 ### Render a Frame
 
-To render the UI, an application calls`Terminal::draw()` with a closure that accepts a `Frame`. The
+To render the UI, an application calls `Terminal::draw()` with a closure that accepts a `Frame`. The
 most important method on `Frame` is `render_widget()` which renders any type that implements the
-[`Widget` trait](/concepts/widgets) such as `Paragraph`, `List` etc., We will implement the `Widget`
-for the `App` struct so that the code related to rendering is organized in a single place. This
-allows us to call `Frame::render_widget()` with the app in the closure passed to `Terminal::draw`.
+[`Widget` trait](/concepts/widgets) such as `Paragraph`, `List` etc. We will implement the `Widget`
+trait for the `App` struct so that the code related to rendering is organized in a single place.
+This allows us to call `Frame::render_widget()` with the app in the closure passed to
+`Terminal::draw`.
 
 First, add a new `impl Widget for &App` block. We implement this on a reference to the App type, as
 the render function will not mutate any state, and we want to be able to use the app after the call
@@ -208,7 +209,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 
 The application needs to accept events that come from the user via the standard input. The only
 events this application needs to worry about are key events. For information on other available
-events, see the [Crossterm events module] docs. These include window resize and focus, paste and
+events, see the [Crossterm events module] docs. These include window resize and focus, paste, and
 mouse events.
 
 In more advanced applications, events might come from the system, over the network, or from other

--- a/src/content/docs/tutorials/counter-app/error-handling.md
+++ b/src/content/docs/tutorials/counter-app/error-handling.md
@@ -10,8 +10,8 @@ A full copy of the code for this page is available in the github repository for 
 <https://github.com/ratatui-org/ratatui-website/tree/main/code/counter-app-error-handling>.
 
 In the previous section, you created a [basic counter app](../basic-app/) that responds to the user
-pressing a the **Left** and **Right** arrow keys to control the value of a counter. This tutorial
-will start with that code and add error and panic handling.
+pressing the **Left** and **Right** arrow keys to control the value of a counter. This tutorial will
+start with that code and add error and panic handling.
 
 A quick reminder of where we left off in the basic app:
 
@@ -41,7 +41,7 @@ the main function does not have a chance to restore the terminal state before it
 {{#include @code/counter-app-basic/src/main.rs:main }}
 ```
 
-The application's default panic handler runs by displays the details messed up. This is because raw
+The application's default panic handler runs and displays the details messed up. This is because raw
 mode stops the terminal from interpreting newlines in the usual way. The shell prompt is also
 rendered at the wrong place.
 
@@ -109,7 +109,7 @@ restoring the terminal. The eyre hook now automatically handles this.
 Color eyre works by adding extra information to Results. You can add context to the errors by
 calling `wrap_err` (defined on the `color_eyre::eyre::WrapErr` trait).
 
-Update the `App::run function to add some information about the update function failing and change
+Update the `App::run` function to add some information about the update function failing and change
 the return value.
 
 ```rust {4,7}

--- a/src/content/docs/tutorials/json-editor/main.md
+++ b/src/content/docs/tutorials/json-editor/main.md
@@ -45,8 +45,8 @@ For more information, please read the
 
 Now that we have prepared the terminal for our application to run, it is time to actually run it.
 
-First, we need to create an instance of our `ApplicationState` or `app`, to hold all of the
-program's state, and then we will call our function which handles the event and draw loop.
+First, we need to create an instance of our `App` to hold all of the program's state, and then we
+will call our function which handles the event and draw loop.
 
 ```rust
     // --snip--
@@ -164,8 +164,8 @@ if let Event::Key(key) = event::read()? {
 
 and then match the results.
 
-Alternatively, we can set up a thread to run in the background to poll and send `Event`s (as we did
-in the "counter" tutorial). Let's keep things simple here for the sake of illustration.
+Alternatively, we can set up a thread to run in the background to poll and send `Event`s, but let's
+keep things simple here for the sake of illustration.
 
 Note that the process for polling events will vary on the backend you are utilizing, and you will
 need to refer to the documentation of that backend for more information.
@@ -197,7 +197,7 @@ The next handler we will prepare, will handle events while the application is on
 outputting the json. It is simply a `y/n` question, so that is all we listen for. We also add an
 alternate exit key with `q`. If the user chooses to output the json, we return an `Ok(true)` that
 indicates that our `main` function should call `app.print_json()` to perform the serialization and
-printing for us after resetting the terminal to normal
+printing for us after resetting the terminal to normal.
 
 ```rust
                 // --snip--

--- a/src/content/docs/tutorials/json-editor/ui-main.md
+++ b/src/content/docs/tutorials/json-editor/ui-main.md
@@ -59,9 +59,9 @@ formatted key-value pairs. Finally, we create the `List` widget, and render it.
 
 ## The bottom navigational bar
 
-It can help new users of your application, to see hints about what keys they can press. For this, we
+It can help new users of your application to see hints about what keys they can press. For this, we
 are going to implement two bars, and another layout. These two bars will contain information on 1)
-The current screen (`Main`, `Editing`, and `Exiting`), and 2) what keybinds are available.
+the current screen (`Main`, `Editing`, and `Exiting`), and 2) what keybinds are available.
 
 Here, we will create a `Vec` of `Span` which will be converted later into a single line by the
 `Paragraph`. (A `Span` is different from a `Line`, because a `Span` indicates a section of `Text`
@@ -96,7 +96,7 @@ We will create a new layout in this space by passing it (`chunks[2]`) as the par
 {{#include @code/ratatui-json-editor-app/src/ui.rs:lower_navigation_layout}}
 ```
 
-This code is the visual equivalent of this:
+The visual equivalent of this code is:
 
 ```svgbob
 +---------------------------------+ Constraint::Length  == 3


### PR DESCRIPTION
I noticed some missing words and grammatical errors while reading through the tutorials.