### PR TITLE
Resolved broken links

### DIFF
--- a/src/content/docs/showcase/third-party-widgets.mdx
+++ b/src/content/docs/showcase/third-party-widgets.mdx
@@ -8,7 +8,7 @@ sidebar:
 import LinkBadge from "/src/components/LinkBadge.astro";
 
 To add your widgets to this list, please read the
-[Third Party Widgets README](https://github.com/ratatui/ratatui-website/blob/main/src/content/docs/showcase/third-party-widgets.mdx)
+[Third Party Widgets README](https://github.com/ratatui/ratatui-website/blob/main/code/showcase/widget-showcase-third-party/README.md)
 
 ## Ratatui-image <LinkBadge text="Crate" href="https://crates.io/crates/ratatui-image" /> <LinkBadge text="Docs" href="https://docs.rs/ratatui-image" /> <LinkBadge text="GitHub" href="https://github.com/benjajaja/ratatui-image" />
 

--- a/src/content/docs/showcase/widgets.mdx
+++ b/src/content/docs/showcase/widgets.mdx
@@ -10,10 +10,9 @@ import LinkBadge from "/src/components/LinkBadge.astro";
 The following widgets are built-in and available in the `ratatui` crate. They are all documented in
 the [API docs](https://docs.rs/ratatui/latest/ratatui/widgets/index.html).
 
-Note: these screenshots are created using the [widget-showcase] project and [VHS]. See
-https://github.com/ratatui/ratatui-website/issues/249 for information about how to contribute.
+Note: these screenshots are created using the [widget-showcase] project and [VHS]. Refer to these projects if you’d like to contribute.
 
-[widget-showcase]: https://github.com/ratatui/ratatui-website/blob/main/code/widget-showcase
+[widget-showcase]: https://github.com/ratatui/ratatui-website/tree/main/code/showcase/widget-showcase
 [VHS]: https://github.com/charmbracelet/vhs
 
 ## Block <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/block/struct.Block.html" text="Docs" /> <LinkBadge href="https://ratatui.rs/examples/widgets/block/" text="Example Code" />

--- a/src/content/docs/showcase/widgets.mdx
+++ b/src/content/docs/showcase/widgets.mdx
@@ -10,7 +10,11 @@ import LinkBadge from "/src/components/LinkBadge.astro";
 The following widgets are built-in and available in the `ratatui` crate. They are all documented in
 the [API docs](https://docs.rs/ratatui/latest/ratatui/widgets/index.html).
 
-Note: these screenshots are created using the [widget-showcase] project and [VHS]. Refer to these projects if you’d like to contribute.
+:::note
+
+These screenshots are created using the [widget-showcase] project and [VHS]. Refer to these projects if you’d like to contribute.
+
+:::
 
 [widget-showcase]: https://github.com/ratatui/ratatui-website/tree/main/code/showcase/widget-showcase
 [VHS]: https://github.com/charmbracelet/vhs


### PR DESCRIPTION
**Description:**

This update some links in showcase pages:
Built-in widgets:
- Removes the direct link to the GitHub issue regarding contributions.
- Added the new link for the project to make contributions about widgets.
Third-party widgets:
- Updated the link to the README to make contributions.

 It is the solution for the #957.