### PR TITLE
Added external icon to external links

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,7 @@ import remarkSvgBob from "remark-svgbob";
 import remarkYoutube from "remark-youtube";
 import starlightLinksValidator from "starlight-links-validator";
 import { collapsibleFrames } from "/src/plugins/collapsible-frames";
+import rehypeExternalLink from "/src/plugins/rehype-external-link";
 import remarkIncludeCode from "/src/plugins/remark-code-import";
 
 // https://astro.build/config
@@ -27,7 +28,7 @@ export default defineConfig({
   },
   markdown: {
     remarkPlugins: [remarkIncludeCode, emoji, remarkYoutube, remarkSvgBob],
-    rehypePlugins: [rehypeMermaid],
+    rehypePlugins: [rehypeMermaid, rehypeExternalLink],
   },
   integrations: [
     starlight({

--- a/src/plugins/rehype-external-link.ts
+++ b/src/plugins/rehype-external-link.ts
@@ -13,14 +13,14 @@ function rehypeExternalLink() {
       // We set a flag so we can skip adding the external‑link icon for this specific link.
       if (node.tagName === "h2") {
         if (node.children[0].type === "element" && node.children[0].tagName === "a") {
-          isTagaInsideH2 = true;
+          isATagInsideH2 = true;
         }
       }
       // Process every <a> element encountered during traversal.
       if (node.tagName === "a" && node.properties?.href) {
         // If the link was inside an <h2>, reset the flag and skip icon logic.
-        if (isTagaInsideH2) {
-          isTagaInsideH2 = false;
+        if (isATagInsideH2) {
+          isATagInsideH2 = false;
         } else {
           // Normal external-link handling
           const href: string = node.properties.href as string;

--- a/src/plugins/rehype-external-link.ts
+++ b/src/plugins/rehype-external-link.ts
@@ -6,7 +6,7 @@ export default rehypeExternalLink;
  */
 function rehypeExternalLink() {
   const iconNode = getExternalLinkSvgNode();
-  let isTagaInsideH2 = false;
+  let isATagInsideH2 = false;
   return (tree: Node) => {
     visit(tree, "element", (node: any) => {
       // Detect when a link is the first child of an <h2> element.

--- a/src/plugins/rehype-external-link.ts
+++ b/src/plugins/rehype-external-link.ts
@@ -5,27 +5,73 @@ export default rehypeExternalLink;
  * to all external <a> tags in Markdown content.
  */
 function rehypeExternalLink() {
-  // SVG copied from Starlight’s <IconExternalLink /> (Heroicons outline)
-  const iconSVG = `<svg aria-hidden="true" class="inline-block" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="--sl-icon-size: 1.5rem;">
-<path d="M19.33 10.18a1 1 0 0 1-.77 0 1 1 0 0 1-.62-.93l.01-1.83-8.2 8.2a1 1 0 0 1-1.41-1.42l8.2-8.2H14.7a1 1 0 0 1 0-2h4.25a1 1 0 0 1 1 1v4.25a1 1 0 0 1-.62.93Z"></path>
-<path d="M11 4a1 1 0 1 1 0 2H7a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-4a1 1 0 1 1 2 0v4a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V7a3 3 0 0 1 3-3h4Z">
-</path>
-</svg>`;
-
+  const iconNode = getExternalLinkSvgNode();
+  let isTagaInsideH2 = false;
   return (tree: Node) => {
     visit(tree, "element", (node: any) => {
+      // Detect when a link is the first child of an <h2> element.
+      // We set a flag so we can skip adding the external‑link icon for this specific link.
+      if (node.tagName === "h2") {
+        if (node.children[0].type === "element" && node.children[0].tagName === "a") {
+          isTagaInsideH2 = true;
+        }
+      }
+      // Process every <a> element encountered during traversal.
       if (node.tagName === "a" && node.properties?.href) {
-        const href: string = node.properties.href;
-        const isExternal = /^https?:\/\//.test(href);
+        // If the link was inside an <h2>, reset the flag and skip icon logic.
+        if (isTagaInsideH2) {
+          isTagaInsideH2 = false;
+        } else {
+          // Normal external-link handling
+          const href: string = node.properties.href as string;
+          const isExternal = /^https?:\/\//.test(href);
 
-        if (isExternal) {
-          node.properties.target = "_blank";
-          node.children.push({
-            type: "raw",
-            value: iconSVG,
-          });
+          if (isExternal) {
+            node.properties.target = "_blank";
+            node.properties.rel = "noopener noreferrer";
+            node.children.push(iconNode);
+          }
         }
       }
     });
+  };
+}
+/**
+ * Returns a virtual node representing the external‑link icon used in Starlight.
+ * The icon is rendered as an SVG element with two path children that form the
+ * double‑arrow shape.  The returned node follows the unist format that
+ * rehype operates on, so it can be appended directly to link nodes.
+ */
+function getExternalLinkSvgNode(): any {
+  return {
+    type: "element",
+    tagName: "svg",
+    properties: {
+      "aria-hidden": "true",
+      className: ["inline-block"],
+      width: "16",
+      height: "16",
+      viewBox: "0 0 24 24",
+      fill: "currentColor",
+      style: "transform: translateY(0.2em); -sl-icon-size: 1.5rem;",
+    },
+    children: [
+      {
+        type: "element",
+        tagName: "path",
+        properties: {
+          d: "M19.33 10.18a1 1 0 0 1-.77 0 1 1 0 0 1-.62-.93l.01-1.83-8.2 8.2a1 1 0 0 1-1.41-1.42l8.2-8.2H14.7a1 1 0 0 1 0-2h4.25a1 1 0 0 1 1 1v4.25a1 1 0 0 1-.62.93Z",
+        },
+        children: [],
+      },
+      {
+        type: "element",
+        tagName: "path",
+        properties: {
+          d: "M11 4a1 1 0 1 1 0 2H7a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-4a1 1 0 1 1 2 0v4a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V7a3 3 0 0 1 3-3h4Z",
+        },
+        children: [],
+      },
+    ],
   };
 }

--- a/src/plugins/rehype-external-link.ts
+++ b/src/plugins/rehype-external-link.ts
@@ -1,0 +1,31 @@
+import { visit } from "unist-util-visit";
+export default rehypeExternalLink;
+/**
+ * Rehype plugin: automatically adds the Starlight-style external link icon
+ * to all external <a> tags in Markdown content.
+ */
+function rehypeExternalLink() {
+  // SVG copied from Starlight’s <IconExternalLink /> (Heroicons outline)
+  const iconSVG = `<svg aria-hidden="true" class="inline-block" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="--sl-icon-size: 1.5rem;">
+<path d="M19.33 10.18a1 1 0 0 1-.77 0 1 1 0 0 1-.62-.93l.01-1.83-8.2 8.2a1 1 0 0 1-1.41-1.42l8.2-8.2H14.7a1 1 0 0 1 0-2h4.25a1 1 0 0 1 1 1v4.25a1 1 0 0 1-.62.93Z"></path>
+<path d="M11 4a1 1 0 1 1 0 2H7a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-4a1 1 0 1 1 2 0v4a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V7a3 3 0 0 1 3-3h4Z">
+</path>
+</svg>`;
+
+  return (tree: Node) => {
+    visit(tree, "element", (node: any) => {
+      if (node.tagName === "a" && node.properties?.href) {
+        const href: string = node.properties.href;
+        const isExternal = /^https?:\/\//.test(href);
+
+        if (isExternal) {
+          node.properties.target = "_blank";
+          node.children.push({
+            type: "raw",
+            value: iconSVG,
+          });
+        }
+      }
+    });
+  };
+}


### PR DESCRIPTION
Added a custom rehype-external-link plugin to add an "external" icon in every external link on the website.

There is yet a plugin that does this, but it is not very customizable, so I prefer to do it myself.

## Final Result

<img width="727" height="459" alt="Screenshot 2025-10-22 at 19: 59: 49" src="https://github.com/user-attachments/assets/31dd040c-3de2-4dfd-8888-ff4290c06a3c" />
<img width="164" height="41" alt="Screenshot 2025-10-22 at 20: 00: 07" src="https://github.com/user-attachments/assets/0c45c5b5-1a35-48b9-9030-a79b1b79de80" />

## Notes
- Added a control that ignores the <a> inside a <h2> (to not put the icon in the showcase/apps page.) 
- Added also the target="_blank" for all the external links (more better in my opinion!)