### PR TITLE
fix several broken links

### DIFF
--- a/src/content/docs/templates/component/config-rs.md
+++ b/src/content/docs/templates/component/config-rs.md
@@ -129,7 +129,7 @@ impl<'de> Deserialize<'de> for KeyBindings {
 ```
 
 Now all we need to do is implement a `parse_key_event` function.
-[You can check the source code for an example of this implementation](https://github.com/ratatui/templates/blob/main/async/template/src/config.rs#L105-L109).
+[You can check the source code for an example of this implementation](https://github.com/ratatui/templates/blob/main/component/template/src/config.rs#L150-L154).
 
 :::tip
 

--- a/src/content/docs/templates/component/index.md
+++ b/src/content/docs/templates/component/index.md
@@ -33,7 +33,7 @@ cd ratatui-hello-world
 ```
 
 You can also use a
-[`template.toml`](https://github.com/ratatui/templates/blob/main/.github/workflows/template.toml)
+[`template.toml`](https://github.com/ratatui/templates/blob/main/component/.github/workflows/template.toml)
 file to skip the prompts:
 
 ```bash

--- a/src/content/docs/tutorials/counter-app/_multiple-files/index.md
+++ b/src/content/docs/tutorials/counter-app/_multiple-files/index.md
@@ -22,7 +22,7 @@ $ tree .
 ```
 
 If you want to explore the code on your own, you can check out the completed source code here:
-<https://github.com/ratatui/ratatui-website/tree/main/code/ratatui-counter-app>
+<https://github.com/ratatui/ratatui-website/tree/main/code/tutorials/ratatui-counter-app>
 
 Let's go ahead and declare these files as modules in `src/main.rs`
 

--- a/src/content/docs/tutorials/counter-app/_multiple-files/main.md
+++ b/src/content/docs/tutorials/counter-app/_multiple-files/main.md
@@ -45,7 +45,7 @@ Sleep 2.5s
 ![Counter app demo](https://user-images.githubusercontent.com/1813121/263404720-41bd81a0-4eec-479c-9333-44363a183613.gif)
 
 You can find the full source code for this multiple files tutorial here:
-<https://github.com/ratatui/ratatui-website/tree/main/code/ratatui-counter-app>.
+<https://github.com/ratatui/ratatui-website/tree/main/code/tutorials/ratatui-counter-app>.
 
 :::note[Homework]
 


### PR DESCRIPTION
Resolves https://github.com/ratatui/templates/issues/120

I stumbled upon a broken link in the docs, and when I went to fix it I ran [lychee](https://github.com/lycheeverse/lychee) and found several more.

I fixed the ones where I was able to figure out the actual location, but there's several more that I'm not sure about, for example https://github.com/ratatui/rust-tui-template

