### PR TITLE
Minor improvements to `config-rs.md`

### DIFF
--- a/src/content/docs/templates/component/config-rs.md
+++ b/src/content/docs/templates/component/config-rs.md
@@ -98,7 +98,8 @@ pub struct Config {
 
 ## Key Bindings and Styles
 
-We are using `serde` to deserialize from a TOML file, and `derive_deref` to be able to write `.get(..)` instead of `.0.get(..)` when we access the `KeyBindings` tuple struct.
+We are using `serde` to deserialize from a TOML file, and `derive_deref` to be able to write
+`.get(..)` instead of `.0.get(..)` when we access the `KeyBindings` tuple struct.
 
 Now the default `KeyEvent` serialized format is not very user friendly, so let's implement our own
 version:

--- a/src/content/docs/templates/component/config-rs.md
+++ b/src/content/docs/templates/component/config-rs.md
@@ -65,10 +65,12 @@ We can set up a `Config` struct using
 
 ```rust
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use color_eyre::eyre::Result;
 use ratatui::crossterm::event::KeyEvent;
-use serde_derive::Deserialize;
+use serde::Deserialize;
+use derive_deref::{Deref, DerefMut};
 
 use crate::action::Action;
 
@@ -96,7 +98,7 @@ pub struct Config {
 
 ## Key Bindings and Styles
 
-We are using `serde` to deserialize from a TOML file.
+We are using `serde` to deserialize from a TOML file, and `derive_deref` to be able to write `.get(..)` instead of `.0.get(..)` when we access the `KeyBindings` tuple struct.
 
 Now the default `KeyEvent` serialized format is not very user friendly, so let's implement our own
 version:

--- a/src/content/docs/templates/component/config-rs.md
+++ b/src/content/docs/templates/component/config-rs.md
@@ -143,7 +143,7 @@ directly.
 
 ```rust
 impl App {
-    fn handle_key_event(&mut self, key: KeyEvent) -> Result<()> {
+    fn handle_key_events(&mut self, key: KeyEvent) -> Result<()> {
         let action_tx = self.action_tx.clone();
         let Some(keymap) = self.config.keybindings.get(&self.mode) else {
             return Ok(());

--- a/src/content/docs/templates/component/config-rs.md
+++ b/src/content/docs/templates/component/config-rs.md
@@ -70,7 +70,6 @@ use std::path::PathBuf;
 use color_eyre::eyre::Result;
 use ratatui::crossterm::event::KeyEvent;
 use serde::Deserialize;
-use derive_deref::{Deref, DerefMut};
 
 use crate::action::Action;
 
@@ -98,8 +97,7 @@ pub struct Config {
 
 ## Key Bindings and Styles
 
-We are using `serde` to deserialize from a TOML file, and `derive_deref` to be able to write
-`.get(..)` instead of `.0.get(..)` when we access the `KeyBindings` tuple struct.
+We are using `serde` to deserialize from a TOML file.
 
 Now the default `KeyEvent` serialized format is not very user friendly, so let's implement our own
 version:


### PR DESCRIPTION
- [consistent naming for the handle_key_events function](https://github.com/ratatui/ratatui-website/commit/78750293e1472b9bb6e8bdc15c61eb2fe51fbb40)
- [fix imports and mention usage of the derive_deref crate](https://github.com/ratatui/ratatui-website/commit/4a59a828d69764f61b604531b07dd18d260883a9)