### PR TITLE
fix: Use hello-world template with cargo-generate

### DIFF
--- a/src/content/docs/tutorials/hello-ratatui/index.md
+++ b/src/content/docs/tutorials/hello-ratatui/index.md
@@ -67,7 +67,7 @@ can find more information about this template in the [Hello World Template READM
 [Hello World Template README]: https://github.com/ratatui/templates/blob/main/hello-world/README.md
 
 ```shell title="create new rust project"
-cargo generate ratatui/templates simple
+cargo generate ratatui/templates hello-world
 ```
 
 :::note


### PR DESCRIPTION
This page outlines starting with the `hello-world` template but the example cargo-generate invocation uses the `simple` template