### PR TITLE
Fix no-std docs referring to non-existent `ratatui-core` version

### DIFF
--- a/src/content/docs/concepts/no-std.md
+++ b/src/content/docs/concepts/no-std.md
@@ -86,7 +86,7 @@ features.
 2. Depend on `ratatui-core` instead of the full `ratatui` crate to avoid backend dependencies:
 
    ```toml
-   ratatui-core = { version = "0.30", default-features = false }
+   ratatui-core = { version = "0.1", default-features = false }
    ```
 
 3. Swap `std` types for their `core`/`alloc` equivalents, for example `core::fmt`,


### PR DESCRIPTION
As per the conversation in the Discord channel, the docs refer to a non-existent v0.30 of `ratatui-core`, while only v0.1 versions are current published. Correction for that small inaccuracy.