### PR TITLE
docs: Don't return result from unit test function

### DIFF
--- a/code/tutorials/counter-app-basic/src/main.rs
+++ b/code/tutorials/counter-app-basic/src/main.rs
@@ -147,7 +147,7 @@ mod tests {
 
     // ANCHOR: handle_key_event test
     #[test]
-    fn handle_key_event() -> io::Result<()> {
+    fn handle_key_event() {
         let mut app = App::default();
         app.handle_key_event(KeyCode::Right.into());
         assert_eq!(app.counter, 1);
@@ -158,8 +158,6 @@ mod tests {
         let mut app = App::default();
         app.handle_key_event(KeyCode::Char('q').into());
         assert!(app.exit);
-
-        Ok(())
     }
     // ANCHOR_END: handle_key_event test
 }


### PR DESCRIPTION
No function in the test function's body returns a result. Thus, making the test function return a result adds no benefit. Not returning a result keeps the test function in line with the other test function above.

I'm a Rust newbie, so correct me if I'm wrong here.