### PR TITLE
docs: Add wireman to showcase

### DIFF
--- a/src/content/docs/showcase/apps.md
+++ b/src/content/docs/showcase/apps.md
@@ -247,6 +247,14 @@ assist with the analysis of networking issues.
 
 ---
 
+## [`wireman`](https://github.com/preiter93/wireman)
+
+A configurable gRPC client for the terminal that works with vim-like motions or with the mouse and system editor,.
+
+![wireman demo](https://github.com/preiter93/wireman/blob/main/example/tape/demo.gif?raw=true)
+
+---
+
 ## [`xplr`](https://github.com/sayanarijit/xplr)
 
 A hackable, minimal, fast TUI file explorer


### PR DESCRIPTION
This PR adds [wireman](https://github.com/preiter93/wireman) to the showcase section.

I've posted it a long time ago in the ratatui forum: https://forum.ratatui.rs/t/wireman-a-grpc-client-for-the-terminal/145

<img width="981" height="820" alt="Screenshot 2026-01-10 at 13 20 02" src="https://github.com/user-attachments/assets/32b5c93c-52c2-4e30-ba16-5deb4fb59573" />