### PR TITLE
fix: open external social links in new tab to preserve docs context

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,7 +2,7 @@
 import Search from "@astrojs/starlight/components/Search.astro";
 import SiteTitle from "@astrojs/starlight/components/SiteTitle.astro";
 import ThemeSelect from "@astrojs/starlight/components/ThemeSelect.astro";
-import SocialIcons from "@astrojs/starlight/components/SocialIcons.astro";
+import SocialIcons from "@components/SocialIcons.astro";
 import LanguageSelect from "@astrojs/starlight/components/LanguageSelect.astro";
 
 const buttons = [

--- a/src/components/SocialIcons.astro
+++ b/src/components/SocialIcons.astro
@@ -8,13 +8,7 @@ const links = config.social || [];
 {
   links.length > 0 &&
     links.map(({ label, href, icon }) => (
-      <a
-        {href}
-        rel="me noopener noreferrer" 
-        target="_blank"
-        aria-label={label}
-        class="sl-flex"
-      >
+      <a {href} rel="me noopener noreferrer" target="_blank" aria-label={label} class="sl-flex">
         <span class="sr-only">{label}</span>
         <Icon name={icon} />
       </a>

--- a/src/components/SocialIcons.astro
+++ b/src/components/SocialIcons.astro
@@ -6,16 +6,19 @@ const links = config.social || [];
 ---
 
 {
-  links.length > 0 && (
-    <>
-      {links.map(({ label, href, icon }) => (
-        <a {href} rel="me noopener noreferrer" target="_blank" class="sl-flex">
-          <span class="sr-only">{label}</span>
-          <Icon name={icon} />
-        </a>
-      ))}
-    </>
-  )
+  links.length > 0 &&
+    links.map(({ label, href, icon }) => (
+      <a
+        {href}
+        rel="me noopener noreferrer" 
+        target="_blank"
+        aria-label={label}
+        class="sl-flex"
+      >
+        <span class="sr-only">{label}</span>
+        <Icon name={icon} />
+      </a>
+    ))
 }
 
 <style>

--- a/src/components/SocialIcons.astro
+++ b/src/components/SocialIcons.astro
@@ -1,32 +1,32 @@
 ---
-import config from 'virtual:starlight/user-config';
-import { Icon } from '@astrojs/starlight/components';
+import config from "virtual:starlight/user-config";
+import { Icon } from "@astrojs/starlight/components";
 
 const links = config.social || [];
 ---
 
 {
-	links.length > 0 && (
-		<>
-			{links.map(({ label, href, icon }) => (
-				<a {href} rel="me noopener noreferrer" target="_blank" class="sl-flex">
-					<span class="sr-only">{label}</span>
-					<Icon name={icon} />
-				</a>
-			))}
-		</>
-	)
+  links.length > 0 && (
+    <>
+      {links.map(({ label, href, icon }) => (
+        <a {href} rel="me noopener noreferrer" target="_blank" class="sl-flex">
+          <span class="sr-only">{label}</span>
+          <Icon name={icon} />
+        </a>
+      ))}
+    </>
+  )
 }
 
 <style>
-	@layer starlight.core {
-		a {
-			color: var(--sl-color-text-accent);
-			padding: 0.5em;
-			margin: -0.5em;
-		}
-		a:hover {
-			opacity: 0.66;
-		}
-	}
+  @layer starlight.core {
+    a {
+      color: var(--sl-color-text-accent);
+      padding: 0.5em;
+      margin: -0.5em;
+    }
+    a:hover {
+      opacity: 0.66;
+    }
+  }
 </style>

--- a/src/components/SocialIcons.astro
+++ b/src/components/SocialIcons.astro
@@ -1,0 +1,32 @@
+---
+import config from 'virtual:starlight/user-config';
+import { Icon } from '@astrojs/starlight/components';
+
+const links = config.social || [];
+---
+
+{
+	links.length > 0 && (
+		<>
+			{links.map(({ label, href, icon }) => (
+				<a {href} rel="me noopener noreferrer" target="_blank" class="sl-flex">
+					<span class="sr-only">{label}</span>
+					<Icon name={icon} />
+				</a>
+			))}
+		</>
+	)
+}
+
+<style>
+	@layer starlight.core {
+		a {
+			color: var(--sl-color-text-accent);
+			padding: 0.5em;
+			margin: -0.5em;
+		}
+		a:hover {
+			opacity: 0.66;
+		}
+	}
+</style>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -7,7 +7,7 @@ template: splash
 tableOfContents: false
 ---
 
-import SocialIcons from "@astrojs/starlight/components/SocialIcons.astro";
+import SocialIcons from "@components/SocialIcons.astro";
 import ThemeSelect from "@astrojs/starlight/components/ThemeSelect.astro";
 
 import heroLight from "@assets/hero-light.png";


### PR DESCRIPTION
## Summary

This PR updates clearly external social links (GitHub, Discord, X, etc.) to open in a new browser tab instead of the current one.

## What changed

- Created a custom `SocialIcons.astro` component that overrides Starlight's default
- Added `target="_blank"` attribute to social links
- Added `rel="noopener noreferrer"` for security best practices when using `target="_blank"`

## Why

When users click on social links (GitHub, Discord, etc.), they expect to stay on the documentation site while the external link opens in a new tab. This prevents users from losing their place in the docs.

## Related Issue

Fixes #1044
