### PR TITLE
fix: update Block widget documentation links to correct URLs

### DIFF
--- a/code/examples/ratatui-examples/examples/README.md
+++ b/code/examples/ratatui-examples/examples/README.md
@@ -101,7 +101,7 @@ cargo run --example=barchart-grouped --features=crossterm
 
 ## Block
 
-Demonstrates the [`Block`](https://docs.rs/ratatui/latest/ratatui/widgets/block/struct.Block.html)
+Demonstrates the [`Block`](https://docs.rs/ratatui/latest/ratatui/widgets/struct.Block.html)
 widget. Source: [block.rs](./block.rs).
 
 ```shell

--- a/src/content/docs/examples/Widgets/block.md
+++ b/src/content/docs/examples/Widgets/block.md
@@ -2,7 +2,7 @@
 title: Block
 ---
 
-Demonstrates the [`Block`](https://docs.rs/ratatui/latest/ratatui/widgets/block/struct.Block.html)
+Demonstrates the [`Block`](https://docs.rs/ratatui/latest/ratatui/widgets/struct.Block.html)
 widget.
 
 ```shell title=run example

--- a/src/content/docs/showcase/widgets.mdx
+++ b/src/content/docs/showcase/widgets.mdx
@@ -21,7 +21,7 @@ if you’d like to contribute.
   https://github.com/ratatui/ratatui-website/tree/main/code/showcase/widget-showcase
 [VHS]: https://github.com/charmbracelet/vhs
 
-## Block <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/block/struct.Block.html" text="Docs" /> <LinkBadge href="https://ratatui.rs/examples/widgets/block/" text="Example Code" />
+## Block <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Block.html" text="Docs" /> <LinkBadge href="https://ratatui.rs/examples/widgets/block/" text="Example Code" />
 
 ![Block](./widgets/block.png)
 


### PR DESCRIPTION
### Fix broken link to `Block` widget documentation

The documentation page at:
https://ratatui.rs/examples/widgets/block/

contained an outdated link to the `Block` widget on docs.rs.

This PR replaces:
https://docs.rs/ratatui/latest/ratatui/widgets/block/struct.Block.html

with the correct URL:
https://docs.rs/ratatui/latest/ratatui/widgets/struct.Block.html
