### PR TITLE
Document showcase submission guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/showcase-submission.yml
+++ b/.github/ISSUE_TEMPLATE/showcase-submission.yml
@@ -1,0 +1,79 @@
+name: Showcase submission
+description: Propose an app or third-party widget for the Ratatui showcase
+title: "Showcase submission: "
+labels:
+  - showcase
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the submission.
+
+        Before filling this out, please read:
+
+        - https://ratatui.rs/recipes/apps/submitting-to-the-showcase/
+        - https://ratatui.rs/recipes/apps/release-your-app/
+
+        The showcase is curated and intentionally selective. If your project is not ready for the
+        showcase yet, Awesome Ratatui, the forum, and Discord are still great places to share it.
+  - type: input
+    id: project
+    attributes:
+      label: Project name
+      placeholder: my-cool-tui
+    validations:
+      required: true
+  - type: input
+    id: repo
+    attributes:
+      label: Repository URL
+      placeholder: https://github.com/owner/repo
+    validations:
+      required: true
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Submission type
+      options:
+        - App
+        - Third-party widget
+    validations:
+      required: true
+  - type: textarea
+    id: pitch
+    attributes:
+      label: What should the showcase viewer notice immediately?
+      description: Explain the core idea the image or GIF is supposed to communicate at a glance.
+      placeholder: The first thing viewers should notice is...
+    validations:
+      required: true
+  - type: textarea
+    id: media
+    attributes:
+      label: Screenshot or GIF
+      description: Paste a direct image URL, GitHub attachment, or GIF link.
+      placeholder: https://...
+    validations:
+      required: true
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Submission checklist
+      options:
+        - label: I read the showcase guidance document linked above.
+          required: true
+        - label: The text is readable when the media is scaled down.
+          required: true
+        - label: The image or GIF focuses on the UI instead of shell commands or setup noise.
+          required: true
+        - label: The media uses strong enough contrast and hierarchy to work on the website.
+          required: true
+        - label: If this is a GIF, it stays on each important state long enough to read.
+          required: true
+        - label: I checked how the media looks on a narrow or mobile-sized viewport.
+          required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else reviewers should know?
+      description: Include links to docs, a crate page, forum post, or Awesome Ratatui entry if helpful.

--- a/.github/ISSUE_TEMPLATE/showcase-submission.yml
+++ b/.github/ISSUE_TEMPLATE/showcase-submission.yml
@@ -48,6 +48,14 @@ body:
     validations:
       required: true
   - type: textarea
+    id: interesting
+    attributes:
+      label: What is interesting or novel about this project?
+      description: Explain what this adds to the showcase beyond looking good.
+      placeholder: The notable part of this app or widget is...
+    validations:
+      required: true
+  - type: textarea
     id: media
     attributes:
       label: Screenshot or GIF
@@ -76,4 +84,5 @@ body:
     id: context
     attributes:
       label: Anything else reviewers should know?
-      description: Include links to docs, a crate page, forum post, or Awesome Ratatui entry if helpful.
+      description:
+        Include links to docs, a crate page, forum post, or Awesome Ratatui entry if helpful.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,14 @@
 <!-- Please read CONTRIBUTING.md before submitting any pull request. -->
 
-<!-- If this PR adds or updates a showcase app, see https://github.com/ratatui/ratatui-website/issues/986 -->
+<!--
+If this PR adds or updates a showcase app or third-party widget, please open a showcase submission
+issue first so we can discuss fit and presentation before review:
+
+https://github.com/ratatui/ratatui-website/issues/new?template=showcase-submission.yml
+
+Also read:
+- https://ratatui.rs/recipes/apps/submitting-to-the-showcase/
+- https://ratatui.rs/recipes/apps/release-your-app/
+
+When you open the PR, link back to the showcase submission issue.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,6 @@ This repo contains the Astro/Starlight site plus a Rust workspace with the code 
 ```sh
 git clone https://github.com/ratatui/ratatui-website
 cd ratatui-website
-
 git lfs install
 git lfs pull
 
@@ -21,12 +20,12 @@ npm install
 npm run dev
 ```
 
-> [!NOTE]  
+> [!NOTE]
 > Using a different package manager may result in errors. `pnpm`, for example, is known not to work
-> because of it's dependency isolation.
-
-> [!NOTE] > `npm install` triggers Playwright's browser download; you can skip the heavy Chromium
-> bundle by hitting Ctrl+C once that download starts if you do not plan to run the end-to-end tests.
+> because of its dependency isolation.
+>
+> `npm install` triggers Playwright's browser download; you can skip the heavy Chromium bundle by
+> hitting Ctrl+C once that download starts if you do not plan to run the end-to-end tests.
 
 ## Commands
 
@@ -62,8 +61,13 @@ note.
 
 ## App showcase criteria
 
-See the current criteria and discussion in <https://github.com/ratatui/ratatui-website/issues/986>
-before adding apps to the showcase.
+Before adding an app or third-party widget to the showcase, read:
+
+- <https://ratatui.rs/recipes/apps/submitting-to-the-showcase/>
+- <https://github.com/ratatui/ratatui-website/issues/986>
+
+The website showcase is curated and intentionally selective. If your project is not a good fit for
+the showcase yet, consider sharing it on Awesome Ratatui, the forum, or Discord first.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,8 @@ npm install
 npm run dev
 ```
 
-> [!NOTE]
-> Using a different package manager may result in errors. `pnpm`, for example, is known not to work
-> because of its dependency isolation.
+> [!NOTE] Using a different package manager may result in errors. `pnpm`, for example, is known not
+> to work because of its dependency isolation.
 >
 > `npm install` triggers Playwright's browser download; you can skip the heavy Chromium bundle by
 > hitting Ctrl+C once that download starts if you do not plan to run the end-to-end tests.
@@ -64,6 +63,7 @@ note.
 Before adding an app or third-party widget to the showcase, read:
 
 - <https://ratatui.rs/recipes/apps/submitting-to-the-showcase/>
+- <https://github.com/ratatui/ratatui-website/issues/new?template=showcase-submission.yml>
 - <https://github.com/ratatui/ratatui-website/issues/986>
 
 The website showcase is curated and intentionally selective. If your project is not a good fit for

--- a/src/content/docs/recipes/apps/index.md
+++ b/src/content/docs/recipes/apps/index.md
@@ -15,3 +15,4 @@ This section covers recipes for developing applications:
 - [Migrate from TUI-rs](./migrate-from-tui-rs/)
 - [Spawn Vim](./spawn-vim/)
 - [Releasing Your App](./release-your-app/)
+- [Submitting to the Showcase](./submitting-to-the-showcase/)

--- a/src/content/docs/recipes/apps/submitting-to-the-showcase.md
+++ b/src/content/docs/recipes/apps/submitting-to-the-showcase.md
@@ -6,11 +6,15 @@ sidebar:
 ---
 
 The Ratatui showcase is curated. It is not meant to be a complete directory of every Ratatui app or
-widget. The goal is to highlight entries that make someone stop, immediately understand what is
-interesting, and want to click through to learn more.
+widget. We are intentionally selecting a set of entries that work well together on the site and
+help show what Ratatui can do. The goal is to highlight entries that make someone stop, immediately
+understand what is interesting, and want to click through to learn more.
 
-That means there is some judgment involved in showcase reviews. We still want the reasoning to be
-clear and consistent, so this page explains what we tend to optimize for and why.
+That means there is some judgment involved in showcase reviews. Sometimes that means rejecting a
+submission, or suggesting changes that are not strictly about the app or widget library itself, but
+about how the entry works as part of the curated set. That can include things like framing,
+capture, pacing, contrast, layout, or how much of the UI is shown. We still want the reasoning to
+be clear and consistent, so this page explains what we tend to optimize for and why.
 
 This guidance consolidates ideas from previous discussions in
 [#986](https://github.com/ratatui/ratatui-website/issues/986),

--- a/src/content/docs/recipes/apps/submitting-to-the-showcase.md
+++ b/src/content/docs/recipes/apps/submitting-to-the-showcase.md
@@ -6,15 +6,15 @@ sidebar:
 ---
 
 The Ratatui showcase is curated. It is not meant to be a complete directory of every Ratatui app or
-widget. We are intentionally selecting a set of entries that work well together on the site and
-help show what Ratatui can do. The goal is to highlight entries that make someone stop, immediately
+widget. We are intentionally selecting a set of entries that work well together on the site and help
+show what Ratatui can do. The goal is to highlight entries that make someone stop, immediately
 understand what is interesting, and want to click through to learn more.
 
 That means there is some judgment involved in showcase reviews. Sometimes that means rejecting a
 submission, or suggesting changes that are not strictly about the app or widget library itself, but
-about how the entry works as part of the curated set. That can include things like framing,
-capture, pacing, contrast, layout, or how much of the UI is shown. We still want the reasoning to
-be clear and consistent, so this page explains what we tend to optimize for and why.
+about how the entry works as part of the curated set. That can include things like framing, capture,
+pacing, contrast, layout, or how much of the UI is shown. We still want the reasoning to be clear
+and consistent, so this page explains what we tend to optimize for and why.
 
 This guidance consolidates ideas from previous discussions in
 [#986](https://github.com/ratatui/ratatui-website/issues/986),

--- a/src/content/docs/recipes/apps/submitting-to-the-showcase.md
+++ b/src/content/docs/recipes/apps/submitting-to-the-showcase.md
@@ -77,11 +77,11 @@ Strong app submissions usually have most of these qualities:
 
 Common reasons for pushback:
 
-- the UI looks too plain, cluttered, or unfinished
-- there is too much whitespace or too many boxes competing for attention
-- the media is visually busy and does not make the app's purpose obvious
-- the color choices reduce readability or fail to create hierarchy
-- the app may be useful, but it is not a strong fit for the curated showcase
+- The UI looks too plain, cluttered, or unfinished
+- There is too much whitespace or too many boxes competing for attention
+- The media is visually busy and does not make the app's purpose obvious
+- The color choices reduce readability or fail to create hierarchy
+- The app may be useful, but it is not a strong fit for the curated showcase
 
 ## The bar for widgets and widget libraries
 

--- a/src/content/docs/recipes/apps/submitting-to-the-showcase.md
+++ b/src/content/docs/recipes/apps/submitting-to-the-showcase.md
@@ -1,0 +1,155 @@
+---
+title: Submitting to the Showcase
+sidebar:
+  order: 11
+  label: Submitting to the Showcase
+---
+
+The Ratatui showcase is curated. It is not meant to be a complete directory of every Ratatui app
+or widget. The goal is to highlight entries that make someone stop, immediately understand what is
+interesting, and want to click through to learn more.
+
+That means showcase reviews are partly subjective. We still want the reasoning to be clear and
+consistent, so this page explains what we tend to optimize for and why.
+
+This guidance is not coming out of nowhere. It consolidates previous discussions in
+[#986](https://github.com/ratatui/ratatui-website/issues/986),
+[#905](https://github.com/ratatui/ratatui-website/issues/905), and
+[#1032](https://github.com/ratatui/ratatui-website/pull/1032), along with feedback repeated across
+showcase submissions and review threads.
+
+If your project is not a good fit for the showcase today, that does not mean it is not useful or
+well made. It often just means it is a better fit for [Awesome Ratatui], the forum, or Discord
+until the presentation is stronger.
+
+## What the showcase is for
+
+The showcase is optimized for:
+
+- first impressions
+- visual clarity at a glance
+- entries that still read well when resized on the website, in a GitHub PR, or on a phone
+- a small number of strong examples rather than a complete catalog
+
+The mental model is simple:
+
+> Someone should be able to see the image or GIF, understand what is compelling within a second or
+> two, and feel like they want to try the project.
+
+## Principles behind the feedback
+
+Most review comments are trying to improve one of these principles:
+
+- Legibility. Text, borders, labels, and structure should still be readable when the media is
+  scaled down.
+- Contrast. Dim text, low-contrast separators, and thin visual details often disappear on the
+  website.
+- Visual hierarchy. The important part of the UI should stand out immediately.
+- Signal over coverage. A single strong view is usually better than showing every possible mode,
+  configuration, or feature.
+- Calm motion. Animation should help people understand the UI, not make it harder to parse.
+- Intentional composition. Empty space, crowded layouts, and too many competing colors make entries
+  feel less polished.
+
+These are the reasons behind feedback such as "use a smaller width", "increase dwell time", or
+"simplify the layout". Those are not arbitrary rules. They are proxies for clarity.
+
+## The bar for apps
+
+The apps page is intentionally selective. In practice, new submissions should look better than a
+large share of the apps already on the page, and the safest submissions usually land closer to the
+top tier than the middle.
+
+Strong app submissions usually have most of these qualities:
+
+- The UI looks polished rather than prototype-like.
+- The purpose of the app is obvious from a single screenshot or short GIF.
+- The visual design feels intentional, with clear hierarchy and spacing.
+- The app uses color and contrast well instead of relying on a flat or muddy palette.
+- The recording focuses on the app, not the shell command used to launch it.
+- The entry feels stable and production-ready rather than experimental or broken.
+
+Common reasons for pushback:
+
+- the UI looks too plain, cluttered, or unfinished
+- there is too much whitespace or too many boxes competing for attention
+- the media is visually busy and does not make the app's purpose obvious
+- the color choices reduce readability or fail to create hierarchy
+- the app may be useful, but it is not a strong fit for the curated showcase
+
+## The bar for widgets and widget libraries
+
+For built-in widgets and third-party widget libraries, the goal is slightly different. We are not
+trying to show every option the widget supports. We are trying to show why someone would want to use
+it.
+
+Strong widget submissions usually:
+
+- choose one or two compelling states instead of every permutation
+- crop or zoom the scene so the widget occupies more of the frame
+- use text sizes that match the rest of the showcase
+- avoid dense grids of tiny examples
+- keep labels readable without pausing frame-by-frame
+
+If a widget is highly configurable, the right place to show every variation is usually your own
+repository or docs. The showcase should usually present a single strong hero view that makes the
+widget's value obvious.
+
+## Media guidelines
+
+These are the practical rules we keep repeating because they work well across the website and
+GitHub:
+
+- Prefer a width in the 800-1200px range. `1200` is a good default ceiling.
+- Prefer the default VHS font size or something visually similar.
+- Use a dark theme unless you have a compelling reason not to.
+- Hide the shell command and unrelated setup noise.
+- Keep the subject large in frame. Remove wasted margins and padding where possible.
+- Give viewers enough dwell time to read the screen before changing state.
+- Use GIFs only when motion helps explain the UI. A screenshot is often better.
+- Avoid fast cuts, simultaneous changes everywhere, or long sequences of tiny states.
+- Check the result on a phone-sized viewport before submitting.
+
+For storage:
+
+- Prefer GitHub attachments, `vhs publish`, your own hosting, or Git LFS.
+- Avoid committing large binary screenshots directly into normal Git history when possible.
+
+## Where to submit instead
+
+Not every project belongs on the curated showcase, but there are still good places to share it:
+
+- [Awesome Ratatui]
+- [Ratatui Forum]
+- [Ratatui Discord]
+
+Those are great places for early projects, niche tools, libraries with less visual focus, or apps
+that are useful but not yet showcase-ready.
+
+## Before opening a PR or issue
+
+Please review your submission against this checklist:
+
+- Does the media make the core idea obvious immediately?
+- Is the text still readable when resized?
+- Does the UI have clear hierarchy and good contrast?
+- Have you removed extra modes, whitespace, and low-value variation?
+- Does the animation linger long enough to understand each important state?
+- Would this stand out positively next to the current showcase entries?
+- Is the project already documented and shared in a place like Awesome Ratatui?
+
+If the answer to several of those is "not yet", you will probably have a better experience by
+iterating on the presentation first.
+
+## Related reading
+
+- [Releasing Your App](./release-your-app/)
+- [App Showcase](../../showcase/apps/)
+- [Third Party Widgets](../../showcase/third-party-widgets/)
+- [Issue #986: Ratatui app showcase criteria](https://github.com/ratatui/ratatui-website/issues/986)
+- [Issue #905: Improve Showcase Apps](https://github.com/ratatui/ratatui-website/issues/905)
+- [PR #1032 discussion](https://github.com/ratatui/ratatui-website/pull/1032)
+
+[Awesome Ratatui]: https://github.com/ratatui/awesome-ratatui
+[Ratatui Discord]: https://discord.gg/pMCEU9hNEj
+[Ratatui Forum]: https://forum.ratatui.rs

--- a/src/content/docs/recipes/apps/submitting-to-the-showcase.md
+++ b/src/content/docs/recipes/apps/submitting-to-the-showcase.md
@@ -5,22 +5,23 @@ sidebar:
   label: Submitting to the Showcase
 ---
 
-The Ratatui showcase is curated. It is not meant to be a complete directory of every Ratatui app
-or widget. The goal is to highlight entries that make someone stop, immediately understand what is
+The Ratatui showcase is curated. It is not meant to be a complete directory of every Ratatui app or
+widget. The goal is to highlight entries that make someone stop, immediately understand what is
 interesting, and want to click through to learn more.
 
-That means showcase reviews are partly subjective. We still want the reasoning to be clear and
-consistent, so this page explains what we tend to optimize for and why.
+That means there is some judgment involved in showcase reviews. We still want the reasoning to be
+clear and consistent, so this page explains what we tend to optimize for and why.
 
-This guidance is not coming out of nowhere. It consolidates previous discussions in
+This guidance consolidates ideas from previous discussions in
 [#986](https://github.com/ratatui/ratatui-website/issues/986),
 [#905](https://github.com/ratatui/ratatui-website/issues/905), and
 [#1032](https://github.com/ratatui/ratatui-website/pull/1032), along with feedback repeated across
 showcase submissions and review threads.
 
 If your project is not a good fit for the showcase today, that does not mean it is not useful or
-well made. It often just means it is a better fit for [Awesome Ratatui], the forum, or Discord
-until the presentation is stronger.
+well made. We encourage you to share it on [Awesome Ratatui], the forum, or Discord. In some cases
+the reason may be presentation, and in others it may be overlap with existing showcase entries or
+the limited space on a curated page.
 
 ## What the showcase is for
 
@@ -29,19 +30,20 @@ The showcase is optimized for:
 - first impressions
 - visual clarity at a glance
 - entries that still read well when resized on the website, in a GitHub PR, or on a phone
+- giving people ideas for making cool TUIs
+- driving traffic to third-party apps and widgets in the ecosystem
+- showing a range of interesting approaches to building with Ratatui
 - a small number of strong examples rather than a complete catalog
 
-The mental model is simple:
-
-> Someone should be able to see the image or GIF, understand what is compelling within a second or
-> two, and feel like they want to try the project.
+A useful test is whether someone can see the image or GIF, understand what is compelling within a
+second or two, and feel like they want to try the project.
 
 ## Principles behind the feedback
 
 Most review comments are trying to improve one of these principles:
 
-- Legibility. Text, borders, labels, and structure should still be readable when the media is
-  scaled down.
+- Legibility. Text, borders, labels, and structure should still be readable when the media is scaled
+  down.
 - Contrast. Dim text, low-contrast separators, and thin visual details often disappear on the
   website.
 - Visual hierarchy. The important part of the UI should stand out immediately.
@@ -127,6 +129,10 @@ Those are great places for early projects, niche tools, libraries with less visu
 that are useful but not yet showcase-ready.
 
 ## Before opening a PR or issue
+
+If you want feedback on a possible showcase entry, open a showcase submission issue first:
+
+- [Open a showcase submission issue](https://github.com/ratatui/ratatui-website/issues/new?template=showcase-submission.yml)
 
 Please review your submission against this checklist:
 

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -218,6 +218,34 @@ main .content-panel:first-child:not(:has(*)) {
   opacity: 1;
 }
 
+/* Tailwind preflight clears list markers globally, but Starlight's markdown styles
+   expect normal list bullets/numbers in prose content. Restore them for docs pages. */
+.sl-markdown-content ul {
+  list-style: disc;
+  padding-inline-start: 1.5rem;
+}
+
+.sl-markdown-content ol {
+  list-style: decimal;
+  padding-inline-start: 1.5rem;
+}
+
+.sl-markdown-content li {
+  display: list-item;
+}
+
+.sl-markdown-content li::marker {
+  color: var(--sl-color-gray-2);
+}
+
+.sl-markdown-content ul ul {
+  list-style: circle;
+}
+
+.sl-markdown-content ul ul ul {
+  list-style: square;
+}
+
 /* On hover bracket effect */
 .bracket-effect {
   position: relative;


### PR DESCRIPTION
## Summary
- add a contributor-facing guide for submitting apps and widget libraries to the showcase
- link the new guidance from `CONTRIBUTING.md` and the app recipes index
- add a showcase submission issue template and restore markdown list markers in prose content

## Testing
- `npx markdownlint-cli2 CONTRIBUTING.md src/content/docs/recipes/apps/index.md src/content/docs/recipes/apps/submitting-to-the-showcase.md`
