### PR TITLE
Fix scrollbar example link in widgets showcase

### DIFF
--- a/src/content/docs/showcase/widgets.mdx
+++ b/src/content/docs/showcase/widgets.mdx
@@ -57,7 +57,7 @@ if you’d like to contribute.
 
 ![Paragraph](./widgets/paragraph.png)
 
-## Scrollbar <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Scrollbar.html" text="Docs" /> <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Scrollbar.html" text="Example Code" />
+## Scrollbar <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Scrollbar.html" text="Docs" /> <LinkBadge href="https://ratatui.rs/examples/widgets/scrollbar/" text="Example Code" />
 
 ![Scrollbar](./widgets/scrollbar.png)
 


### PR DESCRIPTION
Noticed that this was pointing to the wrong URL (both the docs and example code were pointing to https://docs.rs/ratatui/latest/ratatui/widgets/struct.Scrollbar.html).

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->

<!-- If this PR adds or updates a showcase app, see https://github.com/ratatui/ratatui-website/issues/986 -->
