### PR TITLE
Update Astro and Starlight dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@astro-community/astro-embed-youtube": "^0.5.6",
-    "@astrojs/check": "^0.9.3",
-    "@astrojs/partytown": "^2.1.2",
-    "@astrojs/starlight": "^0.36.0",
-    "@astrojs/starlight-tailwind": "^4.0.1",
+    "@astro-community/astro-embed-youtube": "^0.5.10",
+    "@astrojs/check": "^0.9.8",
+    "@astrojs/partytown": "^2.1.7",
+    "@astrojs/starlight": "^0.38.4",
+    "@astrojs/starlight-tailwind": "^5.0.0",
     "@expressive-code/plugin-collapsible-sections": "^0.41.3",
-    "@tailwindcss/vite": "^4.1.14",
-    "astro": "^5.18.1",
+    "@tailwindcss/vite": "^4.2.4",
+    "astro": "^6.1.9",
     "astro-diagram": "^0.7.0",
     "hast-util-select": "^6.0.3",
     "hastscript": "^9.0.0",
@@ -36,11 +36,11 @@
     "rehype-mermaid": "3.0.0",
     "remark-custom-heading-id": "^2.0.0",
     "remark-svgbob": "^1.1.1",
-    "sharp": "^0.33.5",
-    "shiki": "^3.23.0",
-    "starlight-auto-sidebar": "^0.1.4",
-    "starlight-links-validator": "0.14.1",
-    "tailwindcss": "^4.1.14",
+    "sharp": "^0.34.5",
+    "shiki": "^4.0.2",
+    "starlight-auto-sidebar": "^0.3.0",
+    "starlight-links-validator": "0.23.0",
+    "tailwindcss": "^4.2.4",
     "toml": "^3.0.0",
     "tree-sitter": "0.22.1",
     "tree-sitter-rust": "^0.23.2",
@@ -67,14 +67,14 @@
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
     "vfile": "^6.0.3",
-    "vitest": "^3.2.4"
+    "vitest": "^4.1.5"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
   },
   "pnpm": {
     "overrides": {
-      "vite": "6.4.1",
+      "vite": "7.3.2",
       "mermaid": "11.11.0",
       "dompurify": "3.2.6",
       "tar-fs": "^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  vite: 6.4.1
+  vite: 7.3.2
   mermaid: 11.11.0
   dompurify: 3.2.6
   tar-fs: ^3.0.4
@@ -15,29 +15,29 @@ importers:
   .:
     dependencies:
       "@astro-community/astro-embed-youtube":
-        specifier: ^0.5.6
-        version: 0.5.7(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1))
+        specifier: ^0.5.10
+        version: 0.5.10
       "@astrojs/check":
-        specifier: ^0.9.3
-        version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.9.2)
+        specifier: ^0.9.8
+        version: 0.9.8(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.9.2)
       "@astrojs/partytown":
-        specifier: ^2.1.2
-        version: 2.1.4
+        specifier: ^2.1.7
+        version: 2.1.7
       "@astrojs/starlight":
-        specifier: ^0.36.0
-        version: 0.36.3(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1))
+        specifier: ^0.38.4
+        version: 0.38.4(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3))
       "@astrojs/starlight-tailwind":
-        specifier: ^4.0.1
-        version: 4.0.1(@astrojs/starlight@0.36.3(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1)))(tailwindcss@4.2.4)
+        specifier: ^5.0.0
+        version: 5.0.0(@astrojs/starlight@0.38.4(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3)))(tailwindcss@4.2.4)
       "@expressive-code/plugin-collapsible-sections":
         specifier: ^0.41.3
         version: 0.41.7
       "@tailwindcss/vite":
-        specifier: ^4.1.14
-        version: 4.2.4(vite@6.4.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))
+        specifier: ^4.2.4
+        version: 4.2.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
       astro:
-        specifier: ^5.18.1
-        version: 5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1)
+        specifier: ^6.1.9
+        version: 6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3)
       astro-diagram:
         specifier: ^0.7.0
         version: 0.7.0(mermaid@11.11.0)
@@ -63,19 +63,19 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       sharp:
-        specifier: ^0.33.5
-        version: 0.33.5
+        specifier: ^0.34.5
+        version: 0.34.5
       shiki:
-        specifier: ^3.23.0
-        version: 3.23.0
+        specifier: ^4.0.2
+        version: 4.0.2
       starlight-auto-sidebar:
-        specifier: ^0.1.4
-        version: 0.1.4(@astrojs/starlight@0.36.3(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1)))
+        specifier: ^0.3.0
+        version: 0.3.0(@astrojs/starlight@0.38.4(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3)))
       starlight-links-validator:
-        specifier: 0.14.1
-        version: 0.14.1(@astrojs/starlight@0.36.3(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1)))
+        specifier: 0.23.0
+        version: 0.23.0(@astrojs/starlight@0.38.4(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3)))(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3))
       tailwindcss:
-        specifier: ^4.1.14
+        specifier: ^4.2.4
         version: 4.2.4
       toml:
         specifier: ^3.0.0
@@ -151,8 +151,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1)
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@24.12.2)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
 
 packages:
   "@antfu/install-pkg@1.1.0":
@@ -167,18 +167,16 @@ packages:
         integrity: sha512-Oq1d9BGZakE/FyoEtcNeSwM7MpDO2vUBi11RWBZXf75zPsbUVWmUs03EqkRFrcgbXyKTas0BdZWC1wcuSoqSAw==,
       }
 
-  "@astro-community/astro-embed-youtube@0.5.7":
+  "@astro-community/astro-embed-youtube@0.5.10":
     resolution:
       {
-        integrity: sha512-Yq1cw4JCnrjnf/278frWZ9VQyAjyAwUd1CH2XZHFt9pNb5PeFNoRUSPlBvUzN6F/XorkWEEyE2N98rcdyx9mHg==,
+        integrity: sha512-hVlx77KQLjKzElVQnrU5znQ5/E60keVSAPrhuWvQQHuqva5auJtt8YBpOThkwDMuEKXjQybEF1/3C07RZ8MAOQ==,
       }
-    peerDependencies:
-      astro: ^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta
 
-  "@astrojs/check@0.9.4":
+  "@astrojs/check@0.9.8":
     resolution:
       {
-        integrity: sha512-IOheHwCtpUfvogHHsvu0AbeRZEnjJg3MopdLddkJE70mULItS/Vh37BHcI00mcOJcH1vhD3odbpvWokpxam7xA==,
+        integrity: sha512-LDng8446QLS5ToKjRHd3bgUdirvemVVExV7nRyJfW2wV36xuv7vDxwy5NWN9zqeSEDgg0Tv84sP+T3yEq+Zlkw==,
       }
     hasBin: true
     peerDependencies:
@@ -196,22 +194,22 @@ packages:
         integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==,
       }
 
-  "@astrojs/internal-helpers@0.7.2":
+  "@astrojs/compiler@3.0.1":
     resolution:
       {
-        integrity: sha512-KCkCqR3Goym79soqEtbtLzJfqhTWMyVaizUi35FLzgGSzBotSw8DB1qwsu7U96ihOJgYhDk2nVPz+3LnXPeX6g==,
+        integrity: sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==,
       }
 
-  "@astrojs/internal-helpers@0.7.6":
+  "@astrojs/internal-helpers@0.9.0":
     resolution:
       {
-        integrity: sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==,
+        integrity: sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==,
       }
 
-  "@astrojs/language-server@2.15.4":
+  "@astrojs/language-server@2.16.6":
     resolution:
       {
-        integrity: sha512-JivzASqTPR2bao9BWsSc/woPHH7OGSGc9aMxXL4U6egVTqBycB3ZHdBJPuOCVtcGLrzdWTosAqVPz1BVoxE0+A==,
+        integrity: sha512-N990lu+HSFiG57owR0XBkr02BYMgiLCshLf+4QG4v6jjSWkBeQGnzqi+E1L08xFPPJ7eEeXnxPXGLaVv5pa4Ug==,
       }
     hasBin: true
     peerDependencies:
@@ -223,74 +221,68 @@ packages:
       prettier-plugin-astro:
         optional: true
 
-  "@astrojs/markdown-remark@6.3.11":
+  "@astrojs/markdown-remark@7.1.1":
     resolution:
       {
-        integrity: sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==,
+        integrity: sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==,
       }
 
-  "@astrojs/markdown-remark@6.3.6":
+  "@astrojs/mdx@5.0.4":
     resolution:
       {
-        integrity: sha512-bwylYktCTsLMVoCOEHbn2GSUA3c5KT/qilekBKA3CBng0bo1TYjNZPr761vxumRk9kJGqTOtU+fgCAp5Vwokug==,
+        integrity: sha512-tSbuuYueNODiFAFaME7pjHY5lOLoxBYJi1cKd6scw9+a4ZO7C7UGdafEoVAQvOV2eO8a6RaHSAJYGVPL1w8BPA==,
       }
-
-  "@astrojs/mdx@4.3.5":
-    resolution:
-      {
-        integrity: sha512-YB3Hhsvl1BxyY0ARe1OrnVzLNKDPXAz9epYvmL+MQ8A85duSsSLQaO3GHB6/qZJKNoLmP6PptOtCONCKkbhPeQ==,
-      }
-    engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
+    engines: { node: ">=22.12.0" }
     peerDependencies:
-      astro: ^5.0.0
+      astro: ^6.0.0
 
-  "@astrojs/partytown@2.1.4":
+  "@astrojs/partytown@2.1.7":
     resolution:
       {
-        integrity: sha512-loUrAu0cGYFDC6dHVRiomdsBJ41VjDYXPA+B3Br51V5hENFgDSOLju86OIj1TvBACcsB22UQV7BlppODDG5gig==,
+        integrity: sha512-dbffmNmJ+sAJ0/aXSaLX4aI04EZS/2C6Mm/+fmd4ikqWO7hV6nIi0sug8Z3c+yqedJNi1swFvpwluWmGjLHNzw==,
       }
 
-  "@astrojs/prism@3.3.0":
+  "@astrojs/prism@4.0.1":
     resolution:
       {
-        integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==,
+        integrity: sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==,
       }
-    engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
+    engines: { node: ">=22.12.0" }
 
-  "@astrojs/sitemap@3.5.1":
+  "@astrojs/sitemap@3.7.2":
     resolution:
       {
-        integrity: sha512-uX5z52GLtQTgOe8r3jeGmFRYrFe52mdpLYJzqjvL1cdy5Kg3MLOZEvaZ/OCH0fSq0t7e50uJQ6oBMZG0ffszBg==,
+        integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==,
       }
 
-  "@astrojs/starlight-tailwind@4.0.1":
+  "@astrojs/starlight-tailwind@5.0.0":
     resolution:
       {
-        integrity: sha512-AOOEWTGqJ7fG66U04xTmZQZ40oZnUYe4Qljpr+No88ozKywtsD1DiXOrGTeHCnZu0hRtMbRtBGB1fZsf0L62iw==,
+        integrity: sha512-VivF+bWg++4ma/ffr5sgHsd/ONtGdVJIKAaRZ6jmL4yqxy7bviu59MGNi5aW3nd8psP9i/aivBTrpwGxRM1XyA==,
       }
     peerDependencies:
-      "@astrojs/starlight": ">=0.34.0"
+      "@astrojs/starlight": ">=0.38.0"
       tailwindcss: ^4.0.0
 
-  "@astrojs/starlight@0.36.3":
+  "@astrojs/starlight@0.38.4":
     resolution:
       {
-        integrity: sha512-5cm4QVQHUP6ZE52O43TtUpsTvLKdZa9XEs4l3suzuY7Ymsbz4ojtoL9NhistbMqM+/qk6fm6SmxbOL6hQ/LfNA==,
+        integrity: sha512-TGFIr2aVC+gcZCPQzJOO4ZnA/yL3jRnsUDcKlVdEhxhxaOQnWr9lZ9MRScg9zU6uh3HVeZAmmjkLCdTlHdcaZA==,
       }
     peerDependencies:
-      astro: ^5.5.0
+      astro: ^6.0.0
 
-  "@astrojs/telemetry@3.3.0":
+  "@astrojs/telemetry@3.3.1":
     resolution:
       {
-        integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==,
+        integrity: sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw==,
       }
     engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
 
-  "@astrojs/yaml2ts@0.2.2":
+  "@astrojs/yaml2ts@0.2.3":
     resolution:
       {
-        integrity: sha512-GOfvSr5Nqy2z5XiwqTouBBpy5FyI6DEe+/g/Mk5am9SjILN1S5fOEvYK0GuWHg98yS/dobP4m8qyqw/URW35fQ==,
+        integrity: sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==,
       }
 
   "@babel/helper-string-parser@7.27.1":
@@ -372,6 +364,18 @@ packages:
         integrity: sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==,
       }
 
+  "@clack/core@1.2.0":
+    resolution:
+      {
+        integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==,
+      }
+
+  "@clack/prompts@1.2.0":
+    resolution:
+      {
+        integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==,
+      }
+
   "@ctrl/tinycolor@4.1.0":
     resolution:
       {
@@ -391,10 +395,10 @@ packages:
         integrity: sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==,
       }
 
-  "@emmetio/css-parser@0.4.0":
+  "@emmetio/css-parser@0.4.1":
     resolution:
       {
-        integrity: sha512-z7wkxRSZgrQHXVzObGkXG+Vmj3uRlpM11oCZ9pbaz0nFejvCDmAiNDpY75+wgXOcffKpj4rzGtwGaZxfJKsJxw==,
+        integrity: sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==,
       }
 
   "@emmetio/html-matcher@1.3.0":
@@ -427,21 +431,6 @@ packages:
         integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
       }
 
-  "@emnapi/runtime@1.5.0":
-    resolution:
-      {
-        integrity: sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==,
-      }
-
-  "@esbuild/aix-ppc64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ppc64]
-    os: [aix]
-
   "@esbuild/aix-ppc64@0.27.7":
     resolution:
       {
@@ -451,15 +440,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/android-arm64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [android]
-
   "@esbuild/android-arm64@0.27.7":
     resolution:
       {
@@ -467,15 +447,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [android]
-
-  "@esbuild/android-arm@0.25.9":
-    resolution:
-      {
-        integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm]
     os: [android]
 
   "@esbuild/android-arm@0.27.7":
@@ -487,15 +458,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-x64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [android]
-
   "@esbuild/android-x64@0.27.7":
     resolution:
       {
@@ -505,15 +467,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  "@esbuild/darwin-arm64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [darwin]
-
   "@esbuild/darwin-arm64@0.27.7":
     resolution:
       {
@@ -521,15 +474,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [darwin]
-
-  "@esbuild/darwin-x64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [darwin]
 
   "@esbuild/darwin-x64@0.27.7":
@@ -541,15 +485,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  "@esbuild/freebsd-arm64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [freebsd]
-
   "@esbuild/freebsd-arm64@0.27.7":
     resolution:
       {
@@ -557,15 +492,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [freebsd]
-
-  "@esbuild/freebsd-x64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [freebsd]
 
   "@esbuild/freebsd-x64@0.27.7":
@@ -577,15 +503,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  "@esbuild/linux-arm64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [linux]
-
   "@esbuild/linux-arm64@0.27.7":
     resolution:
       {
@@ -593,15 +510,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [linux]
-
-  "@esbuild/linux-arm@0.25.9":
-    resolution:
-      {
-        integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm]
     os: [linux]
 
   "@esbuild/linux-arm@0.27.7":
@@ -613,15 +521,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.25.9":
-    resolution:
-      {
-        integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ia32]
-    os: [linux]
-
   "@esbuild/linux-ia32@0.27.7":
     resolution:
       {
@@ -629,15 +528,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [ia32]
-    os: [linux]
-
-  "@esbuild/linux-loong64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [loong64]
     os: [linux]
 
   "@esbuild/linux-loong64@0.27.7":
@@ -649,15 +539,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.25.9":
-    resolution:
-      {
-        integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [mips64el]
-    os: [linux]
-
   "@esbuild/linux-mips64el@0.27.7":
     resolution:
       {
@@ -665,15 +546,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [mips64el]
-    os: [linux]
-
-  "@esbuild/linux-ppc64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ppc64]
     os: [linux]
 
   "@esbuild/linux-ppc64@0.27.7":
@@ -685,15 +557,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [riscv64]
-    os: [linux]
-
   "@esbuild/linux-riscv64@0.27.7":
     resolution:
       {
@@ -701,15 +564,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [riscv64]
-    os: [linux]
-
-  "@esbuild/linux-s390x@0.25.9":
-    resolution:
-      {
-        integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [s390x]
     os: [linux]
 
   "@esbuild/linux-s390x@0.27.7":
@@ -721,15 +575,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  "@esbuild/linux-x64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [linux]
-
   "@esbuild/linux-x64@0.27.7":
     resolution:
       {
@@ -739,15 +584,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  "@esbuild/netbsd-arm64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [netbsd]
-
   "@esbuild/netbsd-arm64@0.27.7":
     resolution:
       {
@@ -755,15 +591,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [netbsd]
-
-  "@esbuild/netbsd-x64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [netbsd]
 
   "@esbuild/netbsd-x64@0.27.7":
@@ -775,15 +602,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  "@esbuild/openbsd-arm64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [openbsd]
-
   "@esbuild/openbsd-arm64@0.27.7":
     resolution:
       {
@@ -791,15 +609,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [openbsd]
-
-  "@esbuild/openbsd-x64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [openbsd]
 
   "@esbuild/openbsd-x64@0.27.7":
@@ -811,15 +620,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  "@esbuild/openharmony-arm64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [openharmony]
-
   "@esbuild/openharmony-arm64@0.27.7":
     resolution:
       {
@@ -828,15 +628,6 @@ packages:
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [openharmony]
-
-  "@esbuild/sunos-x64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [sunos]
 
   "@esbuild/sunos-x64@0.27.7":
     resolution:
@@ -847,15 +638,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  "@esbuild/win32-arm64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [win32]
-
   "@esbuild/win32-arm64@0.27.7":
     resolution:
       {
@@ -863,15 +645,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [win32]
-
-  "@esbuild/win32-ia32@0.25.9":
-    resolution:
-      {
-        integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ia32]
     os: [win32]
 
   "@esbuild/win32-ia32@0.27.7":
@@ -883,15 +656,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  "@esbuild/win32-x64@0.25.9":
-    resolution:
-      {
-        integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [win32]
-
   "@esbuild/win32-x64@0.27.7":
     resolution:
       {
@@ -900,12 +664,6 @@ packages:
     engines: { node: ">=18" }
     cpu: [x64]
     os: [win32]
-
-  "@expressive-code/core@0.41.3":
-    resolution:
-      {
-        integrity: sha512-9qzohqU7O0+JwMEEgQhnBPOw5DtsQRBXhW++5fvEywsuX44vCGGof1SL5OvPElvNgaWZ4pFZAFSlkNOkGyLwSQ==,
-      }
 
   "@expressive-code/core@0.41.7":
     resolution:
@@ -919,22 +677,22 @@ packages:
         integrity: sha512-uh74qWhAW6FEoNdlQAcHCcGBfuhslLvbWL5Fqmi+db/9mZI/I2G1Sr8NfApTEzD+jiIB/GmdPHV9kbjebkn0+g==,
       }
 
-  "@expressive-code/plugin-frames@0.41.3":
+  "@expressive-code/plugin-frames@0.41.7":
     resolution:
       {
-        integrity: sha512-rFQtmf/3N2CK3Cq/uERweMTYZnBu+CwxBdHuOftEmfA9iBE7gTVvwpbh82P9ZxkPLvc40UMhYt7uNuAZexycRQ==,
+        integrity: sha512-diKtxjQw/979cTglRFaMCY/sR6hWF0kSMg8jsKLXaZBSfGS0I/Hoe7Qds3vVEgeoW+GHHQzMcwvgx/MOIXhrTA==,
       }
 
-  "@expressive-code/plugin-shiki@0.41.3":
+  "@expressive-code/plugin-shiki@0.41.7":
     resolution:
       {
-        integrity: sha512-RlTARoopzhFJIOVHLGvuXJ8DCEme/hjV+ZnRJBIxzxsKVpGPW4Oshqg9xGhWTYdHstTsxO663s0cdBLzZj9TQA==,
+        integrity: sha512-DL605bLrUOgqTdZ0Ot5MlTaWzppRkzzqzeGEu7ODnHF39IkEBbFdsC7pbl3LbUQ1DFtnfx6rD54k/cdofbW6KQ==,
       }
 
-  "@expressive-code/plugin-text-markers@0.41.3":
+  "@expressive-code/plugin-text-markers@0.41.7":
     resolution:
       {
-        integrity: sha512-SN8tkIzDpA0HLAscEYD2IVrfLiid6qEdE9QLlGVSxO1KEw7qYvjpbNBQjUjMr5/jvTJ7ys6zysU2vLPHE0sb2g==,
+        integrity: sha512-Ewpwuc5t6eFdZmWlFyeuy3e1PTQC0jFvw2Q+2bpcWXbOZhPLsT7+h8lsSIJxb5mS7wZko7cKyQ2RLYDyK6Fpmw==,
       }
 
   "@fortawesome/fontawesome-free@6.7.2":
@@ -963,15 +721,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  "@img/sharp-darwin-arm64@0.33.5":
-    resolution:
-      {
-        integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [arm64]
-    os: [darwin]
-
   "@img/sharp-darwin-arm64@0.34.5":
     resolution:
       {
@@ -979,15 +728,6 @@ packages:
       }
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
-    os: [darwin]
-
-  "@img/sharp-darwin-x64@0.33.5":
-    resolution:
-      {
-        integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [x64]
     os: [darwin]
 
   "@img/sharp-darwin-x64@0.34.5":
@@ -999,28 +739,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  "@img/sharp-libvips-darwin-arm64@1.0.4":
-    resolution:
-      {
-        integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==,
-      }
-    cpu: [arm64]
-    os: [darwin]
-
   "@img/sharp-libvips-darwin-arm64@1.2.4":
     resolution:
       {
         integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==,
       }
     cpu: [arm64]
-    os: [darwin]
-
-  "@img/sharp-libvips-darwin-x64@1.0.4":
-    resolution:
-      {
-        integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==,
-      }
-    cpu: [x64]
     os: [darwin]
 
   "@img/sharp-libvips-darwin-x64@1.2.4":
@@ -1031,30 +755,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  "@img/sharp-libvips-linux-arm64@1.0.4":
-    resolution:
-      {
-        integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==,
-      }
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   "@img/sharp-libvips-linux-arm64@1.2.4":
     resolution:
       {
         integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==,
       }
     cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  "@img/sharp-libvips-linux-arm@1.0.5":
-    resolution:
-      {
-        integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==,
-      }
-    cpu: [arm]
     os: [linux]
     libc: [glibc]
 
@@ -1085,30 +791,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linux-s390x@1.0.4":
-    resolution:
-      {
-        integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==,
-      }
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   "@img/sharp-libvips-linux-s390x@1.2.4":
     resolution:
       {
         integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==,
       }
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  "@img/sharp-libvips-linux-x64@1.0.4":
-    resolution:
-      {
-        integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==,
-      }
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -1121,30 +809,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linuxmusl-arm64@1.0.4":
-    resolution:
-      {
-        integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==,
-      }
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   "@img/sharp-libvips-linuxmusl-arm64@1.2.4":
     resolution:
       {
         integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==,
       }
     cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  "@img/sharp-libvips-linuxmusl-x64@1.0.4":
-    resolution:
-      {
-        integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==,
-      }
-    cpu: [x64]
     os: [linux]
     libc: [musl]
 
@@ -1157,16 +827,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  "@img/sharp-linux-arm64@0.33.5":
-    resolution:
-      {
-        integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   "@img/sharp-linux-arm64@0.34.5":
     resolution:
       {
@@ -1174,16 +834,6 @@ packages:
       }
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  "@img/sharp-linux-arm@0.33.5":
-    resolution:
-      {
-        integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [arm]
     os: [linux]
     libc: [glibc]
 
@@ -1217,16 +867,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linux-s390x@0.33.5":
-    resolution:
-      {
-        integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   "@img/sharp-linux-s390x@0.34.5":
     resolution:
       {
@@ -1234,16 +874,6 @@ packages:
       }
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  "@img/sharp-linux-x64@0.33.5":
-    resolution:
-      {
-        integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -1257,16 +887,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linuxmusl-arm64@0.33.5":
-    resolution:
-      {
-        integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   "@img/sharp-linuxmusl-arm64@0.34.5":
     resolution:
       {
@@ -1274,16 +894,6 @@ packages:
       }
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  "@img/sharp-linuxmusl-x64@0.33.5":
-    resolution:
-      {
-        integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [x64]
     os: [linux]
     libc: [musl]
 
@@ -1296,14 +906,6 @@ packages:
     cpu: [x64]
     os: [linux]
     libc: [musl]
-
-  "@img/sharp-wasm32@0.33.5":
-    resolution:
-      {
-        integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [wasm32]
 
   "@img/sharp-wasm32@0.34.5":
     resolution:
@@ -1322,15 +924,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  "@img/sharp-win32-ia32@0.33.5":
-    resolution:
-      {
-        integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [ia32]
-    os: [win32]
-
   "@img/sharp-win32-ia32@0.34.5":
     resolution:
       {
@@ -1338,15 +931,6 @@ packages:
       }
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [ia32]
-    os: [win32]
-
-  "@img/sharp-win32-x64@0.33.5":
-    resolution:
-      {
-        integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [x64]
     os: [win32]
 
   "@img/sharp-win32-x64@0.34.5":
@@ -1400,27 +984,6 @@ packages:
       {
         integrity: sha512-+PO02uGF6L6Cs0Bw8RpGhikVvMWEysfAyl27qTlroUB8jSWr1lL0Sf6zi78ZxlSnmgSY2AMMKVgghnN9jTtwkQ==,
       }
-
-  "@nodelib/fs.scandir@2.1.5":
-    resolution:
-      {
-        integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==,
-      }
-    engines: { node: ">= 8" }
-
-  "@nodelib/fs.stat@2.0.5":
-    resolution:
-      {
-        integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==,
-      }
-    engines: { node: ">= 8" }
-
-  "@nodelib/fs.walk@1.2.8":
-    resolution:
-      {
-        integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
-      }
-    engines: { node: ">= 8" }
 
   "@octokit/app@16.1.2":
     resolution:
@@ -1664,10 +1227,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  "@qwik.dev/partytown@0.11.2":
+  "@qwik.dev/partytown@0.13.2":
     resolution:
       {
-        integrity: sha512-795y49CqBiKiwKAD+QBZlzlqEK275hVcazZ7wBPSfgC23L+vWuA7PJmMpgxojOucZHzYi5rAAQ+IP1I3BKVZxw==,
+        integrity: sha512-Umls4bSkuzqLVcGvf8OgwIn/OldproSAbaQ/iYGe8VPYBpl2CaOSxabWwkeC72LDFqxVL0b0q8XlI8MuChDyzg==,
       }
     engines: { node: ">=18.0.0" }
     hasBin: true
@@ -1869,11 +1432,25 @@ packages:
         integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==,
       }
 
+  "@shikijs/core@4.0.2":
+    resolution:
+      {
+        integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==,
+      }
+    engines: { node: ">=20" }
+
   "@shikijs/engine-javascript@3.23.0":
     resolution:
       {
         integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==,
       }
+
+  "@shikijs/engine-javascript@4.0.2":
+    resolution:
+      {
+        integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==,
+      }
+    engines: { node: ">=20" }
 
   "@shikijs/engine-oniguruma@3.23.0":
     resolution:
@@ -1881,11 +1458,32 @@ packages:
         integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==,
       }
 
+  "@shikijs/engine-oniguruma@4.0.2":
+    resolution:
+      {
+        integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==,
+      }
+    engines: { node: ">=20" }
+
   "@shikijs/langs@3.23.0":
     resolution:
       {
         integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==,
       }
+
+  "@shikijs/langs@4.0.2":
+    resolution:
+      {
+        integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==,
+      }
+    engines: { node: ">=20" }
+
+  "@shikijs/primitive@4.0.2":
+    resolution:
+      {
+        integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==,
+      }
+    engines: { node: ">=20" }
 
   "@shikijs/themes@3.23.0":
     resolution:
@@ -1893,11 +1491,25 @@ packages:
         integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==,
       }
 
+  "@shikijs/themes@4.0.2":
+    resolution:
+      {
+        integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==,
+      }
+    engines: { node: ">=20" }
+
   "@shikijs/types@3.23.0":
     resolution:
       {
         integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==,
       }
+
+  "@shikijs/types@4.0.2":
+    resolution:
+      {
+        integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==,
+      }
+    engines: { node: ">=20" }
 
   "@shikijs/vscode-textmate@10.0.2":
     resolution:
@@ -1911,6 +1523,12 @@ packages:
         integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==,
       }
     engines: { node: ">=10" }
+
+  "@standard-schema/spec@1.1.0":
+    resolution:
+      {
+        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+      }
 
   "@sveltejs/acorn-typescript@1.0.5":
     resolution:
@@ -2057,7 +1675,7 @@ packages:
         integrity: sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==,
       }
     peerDependencies:
-      vite: 6.4.1
+      vite: 7.3.2
 
   "@types/aws-lambda@8.10.161":
     resolution:
@@ -2323,10 +1941,10 @@ packages:
         integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==,
       }
 
-  "@types/node@17.0.45":
+  "@types/node@24.12.2":
     resolution:
       {
-        integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==,
+        integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==,
       }
 
   "@types/node@24.3.1":
@@ -2335,10 +1953,10 @@ packages:
         integrity: sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==,
       }
 
-  "@types/picomatch@3.0.2":
+  "@types/picomatch@4.0.3":
     resolution:
       {
-        integrity: sha512-n0i8TD3UDB7paoMMxA3Y65vUncFJXjcUf7lQY7YyKGl6031FNjfsLs6pdLFCy2GNFxItPJG8GvvpbZc2skH7WA==,
+        integrity: sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==,
       }
 
   "@types/sax@1.2.7":
@@ -2377,92 +1995,92 @@ packages:
         integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
       }
 
-  "@vitest/expect@3.2.4":
+  "@vitest/expect@4.1.5":
     resolution:
       {
-        integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==,
+        integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==,
       }
 
-  "@vitest/mocker@3.2.4":
+  "@vitest/mocker@4.1.5":
     resolution:
       {
-        integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==,
+        integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==,
       }
     peerDependencies:
       msw: ^2.4.9
-      vite: 6.4.1
+      vite: 7.3.2
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  "@vitest/pretty-format@3.2.4":
+  "@vitest/pretty-format@4.1.5":
     resolution:
       {
-        integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==,
+        integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==,
       }
 
-  "@vitest/runner@3.2.4":
+  "@vitest/runner@4.1.5":
     resolution:
       {
-        integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==,
+        integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==,
       }
 
-  "@vitest/snapshot@3.2.4":
+  "@vitest/snapshot@4.1.5":
     resolution:
       {
-        integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==,
+        integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==,
       }
 
-  "@vitest/spy@3.2.4":
+  "@vitest/spy@4.1.5":
     resolution:
       {
-        integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==,
+        integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==,
       }
 
-  "@vitest/utils@3.2.4":
+  "@vitest/utils@4.1.5":
     resolution:
       {
-        integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==,
+        integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==,
       }
 
-  "@volar/kit@2.4.23":
+  "@volar/kit@2.4.28":
     resolution:
       {
-        integrity: sha512-YuUIzo9zwC2IkN7FStIcVl1YS9w5vkSFEZfPvnu0IbIMaR9WHhc9ZxvlT+91vrcSoRY469H2jwbrGqpG7m1KaQ==,
+        integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==,
       }
     peerDependencies:
       typescript: "*"
 
-  "@volar/language-core@2.4.23":
+  "@volar/language-core@2.4.28":
     resolution:
       {
-        integrity: sha512-hEEd5ET/oSmBC6pi1j6NaNYRWoAiDhINbT8rmwtINugR39loROSlufGdYMF9TaKGfz+ViGs1Idi3mAhnuPcoGQ==,
+        integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==,
       }
 
-  "@volar/language-server@2.4.23":
+  "@volar/language-server@2.4.28":
     resolution:
       {
-        integrity: sha512-k0iO+tybMGMMyrNdWOxgFkP0XJTdbH0w+WZlM54RzJU3WZSjHEupwL30klpM7ep4FO6qyQa03h+VcGHD4Q8gEg==,
+        integrity: sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==,
       }
 
-  "@volar/language-service@2.4.23":
+  "@volar/language-service@2.4.28":
     resolution:
       {
-        integrity: sha512-h5mU9DZ/6u3LCB9xomJtorNG6awBNnk9VuCioGsp6UtFiM8amvS5FcsaC3dabdL9zO0z+Gq9vIEMb/5u9K6jGQ==,
+        integrity: sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==,
       }
 
-  "@volar/source-map@2.4.23":
+  "@volar/source-map@2.4.28":
     resolution:
       {
-        integrity: sha512-Z1Uc8IB57Lm6k7q6KIDu/p+JWtf3xsXJqAX/5r18hYOTpJyBn0KXUR8oTJ4WFYOcDzWC9n3IflGgHowx6U6z9Q==,
+        integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==,
       }
 
-  "@volar/typescript@2.4.23":
+  "@volar/typescript@2.4.28":
     resolution:
       {
-        integrity: sha512-lAB5zJghWxVPqfcStmAP1ZqQacMpe90UrP5RJ3arDyrhy4aCUQqmxPPLB2PWDKugvylmO41ljK7vZ+t6INMTag==,
+        integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==,
       }
 
   "@vscode/emmet-helper@2.11.0":
@@ -2493,6 +2111,14 @@ packages:
     engines: { node: ">=0.4.0" }
     hasBin: true
 
+  acorn@8.16.0:
+    resolution:
+      {
+        integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==,
+      }
+    engines: { node: ">=0.4.0" }
+    hasBin: true
+
   agent-base@6.0.2:
     resolution:
       {
@@ -2500,16 +2126,21 @@ packages:
       }
     engines: { node: ">= 6.0.0" }
 
+  ajv-draft-04@1.0.0:
+    resolution:
+      {
+        integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==,
+      }
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@8.17.1:
     resolution:
       {
         integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==,
-      }
-
-  ansi-align@3.0.1:
-    resolution:
-      {
-        integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==,
       }
 
   ansi-escapes@7.0.0:
@@ -2601,20 +2232,20 @@ packages:
     peerDependencies:
       mermaid: 11.11.0
 
-  astro-expressive-code@0.41.3:
+  astro-expressive-code@0.41.7:
     resolution:
       {
-        integrity: sha512-u+zHMqo/QNLE2eqYRCrK3+XMlKakv33Bzuz+56V1gs8H0y6TZ0hIi3VNbIxeTn51NLn+mJfUV/A0kMNfE4rANw==,
+        integrity: sha512-hUpogGc6DdAd+I7pPXsctyYPRBJDK7Q7d06s4cyP0Vz3OcbziP3FNzN0jZci1BpCvLn9675DvS7B9ctKKX64JQ==,
       }
     peerDependencies:
-      astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0
+      astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta
 
-  astro@5.18.1:
+  astro@6.1.9:
     resolution:
       {
-        integrity: sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g==,
+        integrity: sha512-NsAHzMzpznB281g2aM5qnBt2QjfH6ttKiZ3hSZw52If8JJ+62kbnBKbyKhR2glQcJLl7Jfe4GSl0DihFZ36rRQ==,
       }
-    engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: ">=9.6.5", pnpm: ">=7.1.0" }
+    engines: { node: ">=22.12.0", npm: ">=9.6.5", pnpm: ">=7.1.0" }
     hasBin: true
 
   axobject-query@4.1.0:
@@ -2706,12 +2337,6 @@ packages:
         integrity: sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==,
       }
 
-  base-64@1.0.0:
-    resolution:
-      {
-        integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==,
-      }
-
   base64-js@1.5.1:
     resolution:
       {
@@ -2748,13 +2373,6 @@ packages:
         integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==,
       }
 
-  boxen@8.0.1:
-    resolution:
-      {
-        integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==,
-      }
-    engines: { node: ">=18" }
-
   brace-expansion@1.1.12:
     resolution:
       {
@@ -2780,30 +2398,16 @@ packages:
         integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
       }
 
-  cac@6.7.14:
-    resolution:
-      {
-        integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==,
-      }
-    engines: { node: ">=8" }
-
-  camelcase@8.0.0:
-    resolution:
-      {
-        integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==,
-      }
-    engines: { node: ">=16" }
-
   ccount@2.0.1:
     resolution:
       {
         integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==,
       }
 
-  chai@5.3.3:
+  chai@6.2.2:
     resolution:
       {
-        integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==,
+        integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
       }
     engines: { node: ">=18" }
 
@@ -2845,13 +2449,6 @@ packages:
         integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==,
       }
 
-  check-error@2.1.1:
-    resolution:
-      {
-        integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==,
-      }
-    engines: { node: ">= 16" }
-
   chevrotain-allstar@0.3.1:
     resolution:
       {
@@ -2886,13 +2483,6 @@ packages:
         integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==,
       }
     engines: { node: ">=8" }
-
-  cli-boxes@3.0.0:
-    resolution:
-      {
-        integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==,
-      }
-    engines: { node: ">=10" }
 
   cli-cursor@5.0.0:
     resolution:
@@ -2941,19 +2531,6 @@ packages:
         integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
       }
 
-  color-string@1.9.1:
-    resolution:
-      {
-        integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==,
-      }
-
-  color@4.2.3:
-    resolution:
-      {
-        integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==,
-      }
-    engines: { node: ">=12.5.0" }
-
   colorette@2.0.20:
     resolution:
       {
@@ -2994,11 +2571,12 @@ packages:
       }
     engines: { node: ">= 12" }
 
-  common-ancestor-path@1.0.1:
+  common-ancestor-path@2.0.0:
     resolution:
       {
-        integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==,
+        integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==,
       }
+    engines: { node: ">= 18" }
 
   concat-map@0.0.1:
     resolution:
@@ -3016,6 +2594,12 @@ packages:
     resolution:
       {
         integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==,
+      }
+
+  convert-source-map@2.0.0:
+    resolution:
+      {
+        integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
       }
 
   cookie-es@1.2.3:
@@ -3413,30 +2997,11 @@ packages:
       supports-color:
         optional: true
 
-  debug@4.4.3:
-    resolution:
-      {
-        integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
-      }
-    engines: { node: ">=6.0" }
-    peerDependencies:
-      supports-color: "*"
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
   decode-named-character-reference@1.2.0:
     resolution:
       {
         integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==,
       }
-
-  deep-eql@5.0.2:
-    resolution:
-      {
-        integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==,
-      }
-    engines: { node: ">=6" }
 
   defu@6.1.7:
     resolution:
@@ -3463,26 +3028,12 @@ packages:
         integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==,
       }
 
-  detect-libc@2.0.4:
-    resolution:
-      {
-        integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==,
-      }
-    engines: { node: ">=8" }
-
   detect-libc@2.1.2:
     resolution:
       {
         integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
       }
     engines: { node: ">=8" }
-
-  deterministic-object-hash@2.0.2:
-    resolution:
-      {
-        integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==,
-      }
-    engines: { node: ">=18" }
 
   devalue@5.7.1:
     resolution:
@@ -3631,10 +3182,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  es-module-lexer@1.7.0:
+  es-module-lexer@2.1.0:
     resolution:
       {
-        integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
+        integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==,
       }
 
   esast-util-from-estree@2.0.0:
@@ -3648,14 +3199,6 @@ packages:
       {
         integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==,
       }
-
-  esbuild@0.25.9:
-    resolution:
-      {
-        integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==,
-      }
-    engines: { node: ">=18" }
-    hasBin: true
 
   esbuild@0.27.7:
     resolution:
@@ -3758,17 +3301,17 @@ packages:
       }
     engines: { node: ">=16.17" }
 
-  expect-type@1.2.2:
+  expect-type@1.3.0:
     resolution:
       {
-        integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==,
+        integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
       }
     engines: { node: ">=12.0.0" }
 
-  expressive-code@0.41.3:
+  expressive-code@0.41.7:
     resolution:
       {
-        integrity: sha512-YLnD62jfgBZYrXIPQcJ0a51Afv9h8VlWqEGK9uU2T5nL/5rb8SnA86+7+mgCZe5D34Tff5RNEA5hjNVJYHzrFg==,
+        integrity: sha512-2wZjC8OQ3TaVEMcBtYY4Va3lo6J+Ai9jf3d4dbhURMJcU4Pbqe6EcHe424MIZI0VHUA1bR6xdpoHYi3yxokWqA==,
       }
 
   exsolve@1.0.7:
@@ -3809,12 +3352,17 @@ packages:
         integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==,
       }
 
-  fast-glob@3.3.3:
+  fast-string-truncated-width@1.2.1:
     resolution:
       {
-        integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==,
+        integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==,
       }
-    engines: { node: ">=8.6.0" }
+
+  fast-string-width@1.1.0:
+    resolution:
+      {
+        integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==,
+      }
 
   fast-uri@3.1.0:
     resolution:
@@ -3822,10 +3370,10 @@ packages:
         integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==,
       }
 
-  fastq@1.19.1:
+  fast-wrap-ansi@0.1.6:
     resolution:
       {
-        integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==,
+        integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==,
       }
 
   fd-slicer@1.1.0:
@@ -3929,13 +3477,6 @@ packages:
         integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==,
       }
 
-  glob-parent@5.1.2:
-    resolution:
-      {
-        integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
-      }
-    engines: { node: ">= 6" }
-
   glob@7.2.3:
     resolution:
       {
@@ -3967,6 +3508,13 @@ packages:
       {
         integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==,
       }
+
+  has-flag@5.0.1:
+    resolution:
+      {
+        integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==,
+      }
+    engines: { node: ">=12" }
 
   hast-util-embedded@3.0.0:
     resolution:
@@ -4165,12 +3713,6 @@ packages:
         integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
       }
 
-  import-meta-resolve@4.2.0:
-    resolution:
-      {
-        integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==,
-      }
-
   inflight@1.0.6:
     resolution:
       {
@@ -4212,12 +3754,12 @@ packages:
         integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==,
       }
 
-  is-absolute-url@4.0.1:
+  is-absolute-url@5.0.0:
     resolution:
       {
-        integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==,
+        integrity: sha512-sdJyNpBnQHuVnBunfzjAecOhZr2+A30ywfFvu3EnxtKLUWfwGgyWUmqHbGZiU6vTfHpCPm5GvLe4BAvlU9n8VQ==,
       }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    engines: { node: ">=20" }
 
   is-alphabetical@2.0.1:
     resolution:
@@ -4229,12 +3771,6 @@ packages:
     resolution:
       {
         integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==,
-      }
-
-  is-arrayish@0.3.2:
-    resolution:
-      {
-        integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==,
       }
 
   is-decimal@2.0.1:
@@ -4251,12 +3787,13 @@ packages:
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
     hasBin: true
 
-  is-extglob@2.1.1:
+  is-docker@4.0.0:
     resolution:
       {
-        integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
+        integrity: sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==,
       }
-    engines: { node: ">=0.10.0" }
+    engines: { node: ">=20" }
+    hasBin: true
 
   is-fullwidth-code-point@3.0.0:
     resolution:
@@ -4278,13 +3815,6 @@ packages:
         integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==,
       }
     engines: { node: ">=18" }
-
-  is-glob@4.0.3:
-    resolution:
-      {
-        integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
-      }
-    engines: { node: ">=0.10.0" }
 
   is-hexadecimal@2.0.1:
     resolution:
@@ -4327,10 +3857,10 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
-  is-wsl@3.1.0:
+  is-wsl@3.1.1:
     resolution:
       {
-        integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==,
+        integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==,
       }
     engines: { node: ">=16" }
 
@@ -4344,19 +3874,6 @@ packages:
     resolution:
       {
         integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==,
-      }
-    hasBin: true
-
-  js-tokens@9.0.1:
-    resolution:
-      {
-        integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==,
-      }
-
-  js-yaml@4.1.0:
-    resolution:
-      {
-        integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==,
       }
     hasBin: true
 
@@ -4403,13 +3920,6 @@ packages:
       {
         integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==,
       }
-
-  kleur@3.0.3:
-    resolution:
-      {
-        integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==,
-      }
-    engines: { node: ">=6" }
 
   kleur@4.1.5:
     resolution:
@@ -4582,10 +4092,10 @@ packages:
       }
     engines: { node: ">=18.0.0" }
 
-  lite-youtube-embed@0.3.3:
+  lite-youtube-embed@0.3.4:
     resolution:
       {
-        integrity: sha512-gFfVVnj6NRjxVfJKo3qoLtpi0v5mn3AcR4eKD45wrxQuxzveFJUb+7Cr6uV6n+DjO8X3p0UzPPquhGt0H/y+NA==,
+        integrity: sha512-aXgxpwK7AIW58GEbRzA8EYaY4LWvF3FKak6B9OtSJmuNyLhX2ouD4cMTxz/yR5HFInhknaYd2jLWOTRTvT8oAw==,
       }
 
   local-pkg@1.1.2:
@@ -4607,12 +4117,6 @@ packages:
         integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==,
       }
 
-  lodash@4.17.21:
-    resolution:
-      {
-        integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==,
-      }
-
   log-update@6.1.0:
     resolution:
       {
@@ -4626,24 +4130,12 @@ packages:
         integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==,
       }
 
-  loupe@3.2.1:
-    resolution:
-      {
-        integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==,
-      }
-
   lru-cache@11.3.5:
     resolution:
       {
         integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==,
       }
     engines: { node: 20 || >=22 }
-
-  magic-string@0.30.19:
-    resolution:
-      {
-        integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==,
-      }
 
   magic-string@0.30.21:
     resolution:
@@ -4780,6 +4272,12 @@ packages:
         integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==,
       }
 
+  mdast-util-to-hast@13.2.1:
+    resolution:
+      {
+        integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==,
+      }
+
   mdast-util-to-markdown@2.1.2:
     resolution:
       {
@@ -4809,13 +4307,6 @@ packages:
       {
         integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==,
       }
-
-  merge2@1.4.1:
-    resolution:
-      {
-        integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
-      }
-    engines: { node: ">= 8" }
 
   mermaid-isomorphic@3.0.4:
     resolution:
@@ -5207,6 +4698,12 @@ packages:
         integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==,
       }
 
+  obug@2.1.1:
+    resolution:
+      {
+        integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
+      }
+
   octokit@5.0.5:
     resolution:
       {
@@ -5258,26 +4755,26 @@ packages:
         integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==,
       }
 
-  p-limit@6.2.0:
+  p-limit@7.3.0:
     resolution:
       {
-        integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==,
+        integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=20" }
 
-  p-queue@8.1.1:
+  p-queue@9.1.2:
     resolution:
       {
-        integrity: sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==,
+        integrity: sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=20" }
 
-  p-timeout@6.1.4:
+  p-timeout@7.0.1:
     resolution:
       {
-        integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==,
+        integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==,
       }
-    engines: { node: ">=14.16" }
+    engines: { node: ">=20" }
 
   package-manager-detector@1.3.0:
     resolution:
@@ -5355,13 +4852,6 @@ packages:
         integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
       }
 
-  pathval@2.0.1:
-    resolution:
-      {
-        integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==,
-      }
-    engines: { node: ">= 14.16" }
-
   pend@1.2.0:
     resolution:
       {
@@ -5391,6 +4881,13 @@ packages:
     resolution:
       {
         integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
+      }
+    engines: { node: ">=12" }
+
+  picomatch@4.0.4:
+    resolution:
+      {
+        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
       }
     engines: { node: ">=12" }
 
@@ -5457,6 +4954,13 @@ packages:
         integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==,
       }
     engines: { node: ">=4" }
+
+  postcss@8.5.12:
+    resolution:
+      {
+        integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
 
   postcss@8.5.6:
     resolution:
@@ -5558,18 +5062,18 @@ packages:
       prettier-plugin-svelte:
         optional: true
 
-  prettier@2.8.7:
-    resolution:
-      {
-        integrity: sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==,
-      }
-    engines: { node: ">=10.13.0" }
-    hasBin: true
-
   prettier@3.4.2:
     resolution:
       {
         integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==,
+      }
+    engines: { node: ">=14" }
+    hasBin: true
+
+  prettier@3.8.3:
+    resolution:
+      {
+        integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==,
       }
     engines: { node: ">=14" }
     hasBin: true
@@ -5587,13 +5091,6 @@ packages:
         integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==,
       }
     engines: { node: ">=0.4.0" }
-
-  prompts@2.4.2:
-    resolution:
-      {
-        integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==,
-      }
-    engines: { node: ">= 6" }
 
   property-information@6.5.0:
     resolution:
@@ -5638,12 +5135,6 @@ packages:
     resolution:
       {
         integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==,
-      }
-
-  queue-microtask@1.2.3:
-    resolution:
-      {
-        integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
       }
 
   radix3@1.1.2:
@@ -5710,10 +5201,10 @@ packages:
         integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==,
       }
 
-  rehype-expressive-code@0.41.3:
+  rehype-expressive-code@0.41.7:
     resolution:
       {
-        integrity: sha512-8d9Py4c/V6I/Od2VIXFAdpiO2kc0SV2qTJsRAaqSIcM9aruW4ASLNe2kOEo1inXAAkIhpFzAHTc358HKbvpNUg==,
+        integrity: sha512-25f8ZMSF1d9CMscX7Cft0TSQIqdwjce2gDOvQ+d/w0FovsMwrSt3ODP4P3Z7wO1jsIJ4eYyaDRnIR/27bd/EMQ==,
       }
 
   rehype-format@5.0.1:
@@ -5897,13 +5388,6 @@ packages:
         integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==,
       }
 
-  reusify@1.1.0:
-    resolution:
-      {
-        integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==,
-      }
-    engines: { iojs: ">=1.0.0", node: ">=0.10.0" }
-
   rfdc@1.4.1:
     resolution:
       {
@@ -5938,12 +5422,6 @@ packages:
         integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==,
       }
 
-  run-parallel@1.2.0:
-    resolution:
-      {
-        integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
-      }
-
   rw@1.3.3:
     resolution:
       {
@@ -5968,26 +5446,12 @@ packages:
         integrity: sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==,
       }
 
-  sax@1.4.1:
-    resolution:
-      {
-        integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==,
-      }
-
   sax@1.6.0:
     resolution:
       {
         integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==,
       }
     engines: { node: ">=11.0.0" }
-
-  semver@7.7.2:
-    resolution:
-      {
-        integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==,
-      }
-    engines: { node: ">=10" }
-    hasBin: true
 
   semver@7.7.4:
     resolution:
@@ -5996,13 +5460,6 @@ packages:
       }
     engines: { node: ">=10" }
     hasBin: true
-
-  sharp@0.33.5:
-    resolution:
-      {
-        integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
 
   sharp@0.34.5:
     resolution:
@@ -6031,6 +5488,13 @@ packages:
         integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==,
       }
 
+  shiki@4.0.2:
+    resolution:
+      {
+        integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==,
+      }
+    engines: { node: ">=20" }
+
   siginfo@2.0.0:
     resolution:
       {
@@ -6044,27 +5508,18 @@ packages:
       }
     engines: { node: ">=14" }
 
-  simple-swizzle@0.2.2:
-    resolution:
-      {
-        integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==,
-      }
-
   sisteransi@1.0.5:
     resolution:
       {
         integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==,
       }
 
-  sitemap@8.0.0:
+  sitemap@9.0.1:
     resolution:
       {
-        integrity: sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==,
+        integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==,
       }
-    engines: { node: ">=14.0.0", npm: ">=6.0.0" }
-    deprecated:
-      "SECURITY: Multiple vulnerabilities fixed in 8.0.1 (XML injection, path traversal, command
-      injection, protocol injection). Upgrade immediately: npm install sitemap@8.0.1"
+    engines: { node: ">=20.19.5", npm: ">=10.8.2" }
     hasBin: true
 
   skin-tone@2.0.0:
@@ -6087,13 +5542,6 @@ packages:
         integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==,
       }
     engines: { node: ">=18" }
-
-  smol-toml@1.4.2:
-    resolution:
-      {
-        integrity: sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g==,
-      }
-    engines: { node: ">= 18" }
 
   smol-toml@1.6.1:
     resolution:
@@ -6128,28 +5576,29 @@ packages:
         integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
       }
 
-  starlight-auto-sidebar@0.1.4:
+  starlight-auto-sidebar@0.3.0:
     resolution:
       {
-        integrity: sha512-TAPcZkp68kJ5LBXahT1GB4NaX2T1APzPHIkh1hCErbcwgXsHQRlHYa4caEOxkpiAtzN7u6RV34Oragaw18hFYA==,
+        integrity: sha512-4ZQXpIA6W8k2ki+2J8NnYyIbvbP8MbuIB6Zls95oJ/tEFYFYLxeOveWYuWKHxyCEJ/JN2k/oMYhUBALvPb25zw==,
       }
-    engines: { node: ">=18.17.1" }
+    engines: { node: ">=22.12.0" }
     peerDependencies:
-      "@astrojs/starlight": ">=0.32.0"
+      "@astrojs/starlight": ">=0.38.0"
 
-  starlight-links-validator@0.14.1:
+  starlight-links-validator@0.23.0:
     resolution:
       {
-        integrity: sha512-qd5zMBezFhE3R/RBW2am58jVMK3ydcHs8TqOOBLimjn+iXqWV/ZkLlpcavoIOd//w72cX3L//lN4TA+a7vdaZg==,
+        integrity: sha512-dpKJdNv170+jyw8HDgPKGIW/MnXUxa3v8RqJrER47jx4fbxvLsITIw0/Y76xzTTrDv8LhQ7t/ExFutUDQqm3FQ==,
       }
-    engines: { node: ">=18.17.1" }
+    engines: { node: ">=22.12.0" }
     peerDependencies:
-      "@astrojs/starlight": ">=0.15.0"
+      "@astrojs/starlight": ">=0.38.0"
+      astro: ">=6.0.0"
 
-  std-env@3.9.0:
+  std-env@4.1.0:
     resolution:
       {
-        integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==,
+        integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==,
       }
 
   stream-replace-string@2.0.0:
@@ -6212,12 +5661,6 @@ packages:
       }
     engines: { node: ">=12" }
 
-  strip-literal@3.1.0:
-    resolution:
-      {
-        integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==,
-      }
-
   style-to-js@1.1.17:
     resolution:
       {
@@ -6241,6 +5684,20 @@ packages:
       {
         integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==,
       }
+
+  supports-color@10.2.2:
+    resolution:
+      {
+        integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==,
+      }
+    engines: { node: ">=18" }
+
+  supports-hyperlinks@4.4.0:
+    resolution:
+      {
+        integrity: sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==,
+      }
+    engines: { node: ">=20" }
 
   svelte@5.38.7:
     resolution:
@@ -6296,6 +5753,13 @@ packages:
         integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==,
       }
 
+  terminal-link@5.0.0:
+    resolution:
+      {
+        integrity: sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==,
+      }
+    engines: { node: ">=20" }
+
   text-decoder@1.2.7:
     resolution:
       {
@@ -6320,11 +5784,12 @@ packages:
         integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
       }
 
-  tinyexec@0.3.2:
+  tinyclip@0.1.12:
     resolution:
       {
-        integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
+        integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==,
       }
+    engines: { node: ^16.14.0 || >= 17.3.0 }
 
   tinyexec@1.0.1:
     resolution:
@@ -6346,24 +5811,17 @@ packages:
       }
     engines: { node: ">=12.0.0" }
 
-  tinypool@1.1.1:
+  tinyglobby@0.2.16:
     resolution:
       {
-        integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==,
+        integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==,
       }
-    engines: { node: ^18.0.0 || >=20.0.0 }
+    engines: { node: ">=12.0.0" }
 
-  tinyrainbow@2.0.0:
+  tinyrainbow@3.1.0:
     resolution:
       {
-        integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==,
-      }
-    engines: { node: ">=14.0.0" }
-
-  tinyspy@4.0.4:
-    resolution:
-      {
-        integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==,
+        integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
       }
     engines: { node: ">=14.0.0" }
 
@@ -6448,13 +5906,6 @@ packages:
         integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
       }
 
-  type-fest@4.41.0:
-    resolution:
-      {
-        integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==,
-      }
-    engines: { node: ">=16" }
-
   typesafe-path@0.2.2:
     resolution:
       {
@@ -6509,6 +5960,12 @@ packages:
     resolution:
       {
         integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==,
+      }
+
+  undici-types@7.16.0:
+    resolution:
+      {
+        integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==,
       }
 
   unicode-emoji-modifier-base@1.0.0:
@@ -6612,6 +6069,12 @@ packages:
     resolution:
       {
         integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==,
+      }
+
+  unist-util-visit@5.1.0:
+    resolution:
+      {
+        integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==,
       }
 
   universal-github-app-jwt@2.2.2:
@@ -6729,30 +6192,22 @@ packages:
         integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
       }
 
-  vite-node@3.2.4:
+  vite@7.3.2:
     resolution:
       {
-        integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==,
+        integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==,
       }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
-    hasBin: true
-
-  vite@6.4.1:
-    resolution:
-      {
-        integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==,
-      }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
     peerDependencies:
-      "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+      "@types/node": ^20.19.0 || >=22.12.0
       jiti: ">=1.21.0"
-      less: "*"
+      less: ^4.0.0
       lightningcss: ^1.21.0
-      sass: "*"
-      sass-embedded: "*"
-      stylus: "*"
-      sugarss: "*"
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: ">=0.54.8"
+      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -6780,40 +6235,53 @@ packages:
       yaml:
         optional: true
 
-  vitefu@1.1.1:
+  vitefu@1.1.3:
     resolution:
       {
-        integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==,
+        integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==,
       }
     peerDependencies:
-      vite: 6.4.1
+      vite: 7.3.2
     peerDependenciesMeta:
       vite:
         optional: true
 
-  vitest@3.2.4:
+  vitest@4.1.5:
     resolution:
       {
-        integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==,
+        integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==,
       }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
     hasBin: true
     peerDependencies:
       "@edge-runtime/vm": "*"
-      "@types/debug": ^4.1.12
-      "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
-      "@vitest/browser": 3.2.4
-      "@vitest/ui": 3.2.4
+      "@opentelemetry/api": ^1.9.0
+      "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+      "@vitest/browser-playwright": 4.1.5
+      "@vitest/browser-preview": 4.1.5
+      "@vitest/browser-webdriverio": 4.1.5
+      "@vitest/coverage-istanbul": 4.1.5
+      "@vitest/coverage-v8": 4.1.5
+      "@vitest/ui": 4.1.5
       happy-dom: "*"
       jsdom: "*"
+      vite: 7.3.2
     peerDependenciesMeta:
       "@edge-runtime/vm":
         optional: true
-      "@types/debug":
+      "@opentelemetry/api":
         optional: true
       "@types/node":
         optional: true
-      "@vitest/browser":
+      "@vitest/browser-playwright":
+        optional: true
+      "@vitest/browser-preview":
+        optional: true
+      "@vitest/browser-webdriverio":
+        optional: true
+      "@vitest/coverage-istanbul":
+        optional: true
+      "@vitest/coverage-v8":
         optional: true
       "@vitest/ui":
         optional: true
@@ -6822,10 +6290,10 @@ packages:
       jsdom:
         optional: true
 
-  volar-service-css@0.0.62:
+  volar-service-css@0.0.70:
     resolution:
       {
-        integrity: sha512-JwNyKsH3F8PuzZYuqPf+2e+4CTU8YoyUHEHVnoXNlrLe7wy9U3biomZ56llN69Ris7TTy/+DEX41yVxQpM4qvg==,
+        integrity: sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==,
       }
     peerDependencies:
       "@volar/language-service": ~2.4.0
@@ -6833,10 +6301,10 @@ packages:
       "@volar/language-service":
         optional: true
 
-  volar-service-emmet@0.0.62:
+  volar-service-emmet@0.0.70:
     resolution:
       {
-        integrity: sha512-U4dxWDBWz7Pi4plpbXf4J4Z/ss6kBO3TYrACxWNsE29abu75QzVS0paxDDhI6bhqpbDFXlpsDhZ9aXVFpnfGRQ==,
+        integrity: sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg==,
       }
     peerDependencies:
       "@volar/language-service": ~2.4.0
@@ -6844,10 +6312,10 @@ packages:
       "@volar/language-service":
         optional: true
 
-  volar-service-html@0.0.62:
+  volar-service-html@0.0.70:
     resolution:
       {
-        integrity: sha512-Zw01aJsZRh4GTGUjveyfEzEqpULQUdQH79KNEiKVYHZyuGtdBRYCHlrus1sueSNMxwwkuF5WnOHfvBzafs8yyQ==,
+        integrity: sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==,
       }
     peerDependencies:
       "@volar/language-service": ~2.4.0
@@ -6855,10 +6323,10 @@ packages:
       "@volar/language-service":
         optional: true
 
-  volar-service-prettier@0.0.62:
+  volar-service-prettier@0.0.70:
     resolution:
       {
-        integrity: sha512-h2yk1RqRTE+vkYZaI9KYuwpDfOQRrTEMvoHol0yW4GFKc75wWQRrb5n/5abDrzMPrkQbSip8JH2AXbvrRtYh4w==,
+        integrity: sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg==,
       }
     peerDependencies:
       "@volar/language-service": ~2.4.0
@@ -6869,10 +6337,10 @@ packages:
       prettier:
         optional: true
 
-  volar-service-typescript-twoslash-queries@0.0.62:
+  volar-service-typescript-twoslash-queries@0.0.70:
     resolution:
       {
-        integrity: sha512-KxFt4zydyJYYI0kFAcWPTh4u0Ha36TASPZkAnNY784GtgajerUqM80nX/W1d0wVhmcOFfAxkVsf/Ed+tiYU7ng==,
+        integrity: sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==,
       }
     peerDependencies:
       "@volar/language-service": ~2.4.0
@@ -6880,10 +6348,10 @@ packages:
       "@volar/language-service":
         optional: true
 
-  volar-service-typescript@0.0.62:
+  volar-service-typescript@0.0.70:
     resolution:
       {
-        integrity: sha512-p7MPi71q7KOsH0eAbZwPBiKPp9B2+qrdHAd6VY5oTo9BUXatsOAdakTm9Yf0DUj6uWBAaOT01BSeVOPwucMV1g==,
+        integrity: sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==,
       }
     peerDependencies:
       "@volar/language-service": ~2.4.0
@@ -6891,10 +6359,10 @@ packages:
       "@volar/language-service":
         optional: true
 
-  volar-service-yaml@0.0.62:
+  volar-service-yaml@0.0.70:
     resolution:
       {
-        integrity: sha512-k7gvv7sk3wa+nGll3MaSKyjwQsJjIGCHFjVkl3wjaSP2nouKyn9aokGmqjrl39mi88Oy49giog2GkZH526wjig==,
+        integrity: sha512-0c8bXDBeoATF9F6iPIlOuYTuZAC4c+yi0siQo920u7eiBJk8oQmUmg9cDUbR4+Gl++bvGP4plj3fErbJuPqdcQ==,
       }
     peerDependencies:
       "@volar/language-service": ~2.4.0
@@ -6908,10 +6376,10 @@ packages:
         integrity: sha512-5TmXHKllPzfkPhW4UE9sODV3E0bIOJPOk+EERKllf2SmAczjfTmYeq5txco+N3jpF8KIZ6loj/JptpHBQuVQRA==,
       }
 
-  vscode-html-languageservice@5.5.1:
+  vscode-html-languageservice@5.6.2:
     resolution:
       {
-        integrity: sha512-/ZdEtsZ3OiFSyL00kmmu7crFV9KwWR+MgpzjsxO60DQH7sIfHZM892C/E4iDd11EKocr+NYuvOA4Y7uc3QzLEA==,
+        integrity: sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==,
       }
 
   vscode-json-languageservice@4.1.8:
@@ -6921,25 +6389,12 @@ packages:
       }
     engines: { npm: ">=7.0.0" }
 
-  vscode-jsonrpc@6.0.0:
-    resolution:
-      {
-        integrity: sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==,
-      }
-    engines: { node: ">=8.0.0 || >=10.0.0" }
-
   vscode-jsonrpc@8.2.0:
     resolution:
       {
         integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==,
       }
     engines: { node: ">=14.0.0" }
-
-  vscode-languageserver-protocol@3.16.0:
-    resolution:
-      {
-        integrity: sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==,
-      }
 
   vscode-languageserver-protocol@3.17.5:
     resolution:
@@ -6953,24 +6408,11 @@ packages:
         integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==,
       }
 
-  vscode-languageserver-types@3.16.0:
-    resolution:
-      {
-        integrity: sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==,
-      }
-
   vscode-languageserver-types@3.17.5:
     resolution:
       {
         integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==,
       }
-
-  vscode-languageserver@7.0.0:
-    resolution:
-      {
-        integrity: sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==,
-      }
-    hasBin: true
 
   vscode-languageserver@9.0.1:
     resolution:
@@ -7038,13 +6480,6 @@ packages:
     engines: { node: ">=8" }
     hasBin: true
 
-  widest-line@5.0.0:
-    resolution:
-      {
-        integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==,
-      }
-    engines: { node: ">=18" }
-
   wrap-ansi@7.0.0:
     resolution:
       {
@@ -7093,24 +6528,33 @@ packages:
       }
     engines: { node: ">=10" }
 
-  yaml-language-server@1.15.0:
+  yaml-language-server@1.20.0:
     resolution:
       {
-        integrity: sha512-N47AqBDCMQmh6mBLmI6oqxryHRzi33aPFPsJhYy3VTUGCdLHYjGh4FZzpUjRlphaADBBkDmnkM/++KNIOHi5Rw==,
+        integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==,
       }
     hasBin: true
 
-  yaml@2.2.2:
+  yaml@2.7.1:
     resolution:
       {
-        integrity: sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==,
+        integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==,
       }
     engines: { node: ">= 14" }
+    hasBin: true
 
   yaml@2.8.1:
     resolution:
       {
         integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==,
+      }
+    engines: { node: ">= 14.6" }
+    hasBin: true
+
+  yaml@2.8.3:
+    resolution:
+      {
+        integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==,
       }
     engines: { node: ">= 14.6" }
     hasBin: true
@@ -7121,6 +6565,13 @@ packages:
         integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
       }
     engines: { node: ">=12" }
+
+  yargs-parser@22.0.0:
+    resolution:
+      {
+        integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==,
+      }
+    engines: { node: ^20.19.0 || ^22.12.0 || >=23 }
 
   yargs@17.7.2:
     resolution:
@@ -7142,47 +6593,16 @@ packages:
       }
     engines: { node: ">=12.20" }
 
-  yocto-spinner@0.2.3:
-    resolution:
-      {
-        integrity: sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==,
-      }
-    engines: { node: ">=18.19" }
-
-  yoctocolors@2.1.2:
-    resolution:
-      {
-        integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==,
-      }
-    engines: { node: ">=18" }
-
   zimmerframe@1.1.2:
     resolution:
       {
         integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==,
       }
 
-  zod-to-json-schema@3.25.2:
+  zod@4.3.6:
     resolution:
       {
-        integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==,
-      }
-    peerDependencies:
-      zod: ^3.25.28 || ^4
-
-  zod-to-ts@1.2.0:
-    resolution:
-      {
-        integrity: sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==,
-      }
-    peerDependencies:
-      typescript: ^4.9.4 || ^5.0.2
-      zod: ^3
-
-  zod@3.25.76:
-    resolution:
-      {
-        integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==,
+        integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==,
       }
 
   zwitch@2.0.4:
@@ -7199,14 +6619,13 @@ snapshots:
 
   "@antfu/utils@9.2.0": {}
 
-  "@astro-community/astro-embed-youtube@0.5.7(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1))":
+  "@astro-community/astro-embed-youtube@0.5.10":
     dependencies:
-      astro: 5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1)
-      lite-youtube-embed: 0.3.3
+      lite-youtube-embed: 0.3.4
 
-  "@astrojs/check@0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.9.2)":
+  "@astrojs/check@0.9.8(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.9.2)":
     dependencies:
-      "@astrojs/language-server": 2.15.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.9.2)
+      "@astrojs/language-server": 2.16.6(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.9.2)
       chokidar: 4.0.3
       kleur: 4.1.5
       typescript: 5.9.2
@@ -7219,29 +6638,31 @@ snapshots:
 
   "@astrojs/compiler@2.13.1": {}
 
-  "@astrojs/internal-helpers@0.7.2": {}
+  "@astrojs/compiler@3.0.1": {}
 
-  "@astrojs/internal-helpers@0.7.6": {}
-
-  "@astrojs/language-server@2.15.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.9.2)":
+  "@astrojs/internal-helpers@0.9.0":
     dependencies:
-      "@astrojs/compiler": 2.12.2
-      "@astrojs/yaml2ts": 0.2.2
+      picomatch: 4.0.4
+
+  "@astrojs/language-server@2.16.6(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.9.2)":
+    dependencies:
+      "@astrojs/compiler": 2.13.1
+      "@astrojs/yaml2ts": 0.2.3
       "@jridgewell/sourcemap-codec": 1.5.5
-      "@volar/kit": 2.4.23(typescript@5.9.2)
-      "@volar/language-core": 2.4.23
-      "@volar/language-server": 2.4.23
-      "@volar/language-service": 2.4.23
-      fast-glob: 3.3.3
+      "@volar/kit": 2.4.28(typescript@5.9.2)
+      "@volar/language-core": 2.4.28
+      "@volar/language-server": 2.4.28
+      "@volar/language-service": 2.4.28
       muggle-string: 0.4.1
-      volar-service-css: 0.0.62(@volar/language-service@2.4.23)
-      volar-service-emmet: 0.0.62(@volar/language-service@2.4.23)
-      volar-service-html: 0.0.62(@volar/language-service@2.4.23)
-      volar-service-prettier: 0.0.62(@volar/language-service@2.4.23)(prettier@3.4.2)
-      volar-service-typescript: 0.0.62(@volar/language-service@2.4.23)
-      volar-service-typescript-twoslash-queries: 0.0.62(@volar/language-service@2.4.23)
-      volar-service-yaml: 0.0.62(@volar/language-service@2.4.23)
-      vscode-html-languageservice: 5.5.1
+      tinyglobby: 0.2.15
+      volar-service-css: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-emmet: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-html: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-prettier: 0.0.70(@volar/language-service@2.4.28)(prettier@3.4.2)
+      volar-service-typescript: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-typescript-twoslash-queries: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-yaml: 0.0.70(@volar/language-service@2.4.28)
+      vscode-html-languageservice: 5.6.2
       vscode-uri: 3.1.0
     optionalDependencies:
       prettier: 3.4.2
@@ -7249,14 +6670,13 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  "@astrojs/markdown-remark@6.3.11":
+  "@astrojs/markdown-remark@7.1.1":
     dependencies:
-      "@astrojs/internal-helpers": 0.7.6
-      "@astrojs/prism": 3.3.0
+      "@astrojs/internal-helpers": 0.9.0
+      "@astrojs/prism": 4.0.1
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-to-text: 4.0.2
-      import-meta-resolve: 4.2.0
       js-yaml: 4.1.1
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
@@ -7265,100 +6685,76 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
-      shiki: 3.23.0
+      retext-smartypants: 6.2.0
+      shiki: 4.0.2
       smol-toml: 1.6.1
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/markdown-remark@6.3.6":
+  "@astrojs/mdx@5.0.4(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3))":
     dependencies:
-      "@astrojs/internal-helpers": 0.7.2
-      "@astrojs/prism": 3.3.0
-      github-slugger: 2.0.0
-      hast-util-from-html: 2.0.3
-      hast-util-to-text: 4.0.2
-      import-meta-resolve: 4.2.0
-      js-yaml: 4.1.0
-      mdast-util-definitions: 6.0.0
-      rehype-raw: 7.0.0
-      rehype-stringify: 10.0.1
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
-      remark-rehype: 11.1.2
-      remark-smartypants: 3.0.2
-      shiki: 3.23.0
-      smol-toml: 1.4.2
-      unified: 11.0.5
-      unist-util-remove-position: 5.0.0
-      unist-util-visit: 5.0.0
-      unist-util-visit-parents: 6.0.1
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  "@astrojs/mdx@4.3.5(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1))":
-    dependencies:
-      "@astrojs/markdown-remark": 6.3.6
+      "@astrojs/markdown-remark": 7.1.1
       "@mdx-js/mdx": 3.1.1
-      acorn: 8.15.0
-      astro: 5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1)
-      es-module-lexer: 1.7.0
+      acorn: 8.16.0
+      astro: 6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3)
+      es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
-      kleur: 4.1.5
+      piccolore: 0.1.3
       rehype-raw: 7.0.0
       remark-gfm: 4.0.1
       remark-smartypants: 3.0.2
       source-map: 0.7.6
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/partytown@2.1.4":
+  "@astrojs/partytown@2.1.7":
     dependencies:
-      "@qwik.dev/partytown": 0.11.2
+      "@qwik.dev/partytown": 0.13.2
       mrmime: 2.0.1
 
-  "@astrojs/prism@3.3.0":
+  "@astrojs/prism@4.0.1":
     dependencies:
       prismjs: 1.30.0
 
-  "@astrojs/sitemap@3.5.1":
+  "@astrojs/sitemap@3.7.2":
     dependencies:
-      sitemap: 8.0.0
+      sitemap: 9.0.1
       stream-replace-string: 2.0.0
-      zod: 3.25.76
+      zod: 4.3.6
 
-  "@astrojs/starlight-tailwind@4.0.1(@astrojs/starlight@0.36.3(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1)))(tailwindcss@4.2.4)":
+  "@astrojs/starlight-tailwind@5.0.0(@astrojs/starlight@0.38.4(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3)))(tailwindcss@4.2.4)":
     dependencies:
-      "@astrojs/starlight": 0.36.3(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1))
+      "@astrojs/starlight": 0.38.4(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3))
       tailwindcss: 4.2.4
 
-  "@astrojs/starlight@0.36.3(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1))":
+  "@astrojs/starlight@0.38.4(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3))":
     dependencies:
-      "@astrojs/markdown-remark": 6.3.6
-      "@astrojs/mdx": 4.3.5(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1))
-      "@astrojs/sitemap": 3.5.1
+      "@astrojs/markdown-remark": 7.1.1
+      "@astrojs/mdx": 5.0.4(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3))
+      "@astrojs/sitemap": 3.7.2
       "@pagefind/default-ui": 1.4.0
       "@types/hast": 3.0.4
       "@types/js-yaml": 4.0.9
       "@types/mdast": 4.0.4
-      astro: 5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1)
-      astro-expressive-code: 0.41.3(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1))
+      astro: 6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3)
+      astro-expressive-code: 0.41.7(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
       hast-util-to-string: 3.0.1
       hastscript: 9.0.1
       i18next: 23.16.8
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       klona: 2.0.6
+      magic-string: 0.30.21
       mdast-util-directive: 3.1.0
       mdast-util-to-markdown: 2.1.2
       mdast-util-to-string: 4.0.0
@@ -7373,21 +6769,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/telemetry@3.3.0":
+  "@astrojs/telemetry@3.3.1":
     dependencies:
       ci-info: 4.4.0
-      debug: 4.4.3
       dlv: 1.1.3
       dset: 3.1.4
-      is-docker: 3.0.0
-      is-wsl: 3.1.0
+      is-docker: 4.0.0
+      is-wsl: 3.1.1
       which-pm-runs: 1.1.0
-    transitivePeerDependencies:
-      - supports-color
 
-  "@astrojs/yaml2ts@0.2.2":
+  "@astrojs/yaml2ts@0.2.3":
     dependencies:
-      yaml: 2.8.1
+      yaml: 2.8.3
 
   "@babel/helper-string-parser@7.27.1": {}
 
@@ -7427,6 +6820,18 @@ snapshots:
 
   "@chevrotain/utils@11.0.3": {}
 
+  "@clack/core@1.2.0":
+    dependencies:
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
+
+  "@clack/prompts@1.2.0":
+    dependencies:
+      "@clack/core": 1.2.0
+      fast-string-width: 1.1.0
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
+
   "@ctrl/tinycolor@4.1.0": {}
 
   "@emmetio/abbreviation@2.3.3":
@@ -7437,7 +6842,7 @@ snapshots:
     dependencies:
       "@emmetio/scanner": 1.0.4
 
-  "@emmetio/css-parser@0.4.0":
+  "@emmetio/css-parser@0.4.1":
     dependencies:
       "@emmetio/stream-reader": 2.2.0
       "@emmetio/stream-reader-utils": 0.1.0
@@ -7457,178 +6862,83 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  "@emnapi/runtime@1.5.0":
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  "@esbuild/aix-ppc64@0.25.9":
-    optional: true
-
   "@esbuild/aix-ppc64@0.27.7":
-    optional: true
-
-  "@esbuild/android-arm64@0.25.9":
     optional: true
 
   "@esbuild/android-arm64@0.27.7":
     optional: true
 
-  "@esbuild/android-arm@0.25.9":
-    optional: true
-
   "@esbuild/android-arm@0.27.7":
-    optional: true
-
-  "@esbuild/android-x64@0.25.9":
     optional: true
 
   "@esbuild/android-x64@0.27.7":
     optional: true
 
-  "@esbuild/darwin-arm64@0.25.9":
-    optional: true
-
   "@esbuild/darwin-arm64@0.27.7":
-    optional: true
-
-  "@esbuild/darwin-x64@0.25.9":
     optional: true
 
   "@esbuild/darwin-x64@0.27.7":
     optional: true
 
-  "@esbuild/freebsd-arm64@0.25.9":
-    optional: true
-
   "@esbuild/freebsd-arm64@0.27.7":
-    optional: true
-
-  "@esbuild/freebsd-x64@0.25.9":
     optional: true
 
   "@esbuild/freebsd-x64@0.27.7":
     optional: true
 
-  "@esbuild/linux-arm64@0.25.9":
-    optional: true
-
   "@esbuild/linux-arm64@0.27.7":
-    optional: true
-
-  "@esbuild/linux-arm@0.25.9":
     optional: true
 
   "@esbuild/linux-arm@0.27.7":
     optional: true
 
-  "@esbuild/linux-ia32@0.25.9":
-    optional: true
-
   "@esbuild/linux-ia32@0.27.7":
-    optional: true
-
-  "@esbuild/linux-loong64@0.25.9":
     optional: true
 
   "@esbuild/linux-loong64@0.27.7":
     optional: true
 
-  "@esbuild/linux-mips64el@0.25.9":
-    optional: true
-
   "@esbuild/linux-mips64el@0.27.7":
-    optional: true
-
-  "@esbuild/linux-ppc64@0.25.9":
     optional: true
 
   "@esbuild/linux-ppc64@0.27.7":
     optional: true
 
-  "@esbuild/linux-riscv64@0.25.9":
-    optional: true
-
   "@esbuild/linux-riscv64@0.27.7":
-    optional: true
-
-  "@esbuild/linux-s390x@0.25.9":
     optional: true
 
   "@esbuild/linux-s390x@0.27.7":
     optional: true
 
-  "@esbuild/linux-x64@0.25.9":
-    optional: true
-
   "@esbuild/linux-x64@0.27.7":
-    optional: true
-
-  "@esbuild/netbsd-arm64@0.25.9":
     optional: true
 
   "@esbuild/netbsd-arm64@0.27.7":
     optional: true
 
-  "@esbuild/netbsd-x64@0.25.9":
-    optional: true
-
   "@esbuild/netbsd-x64@0.27.7":
-    optional: true
-
-  "@esbuild/openbsd-arm64@0.25.9":
     optional: true
 
   "@esbuild/openbsd-arm64@0.27.7":
     optional: true
 
-  "@esbuild/openbsd-x64@0.25.9":
-    optional: true
-
   "@esbuild/openbsd-x64@0.27.7":
-    optional: true
-
-  "@esbuild/openharmony-arm64@0.25.9":
     optional: true
 
   "@esbuild/openharmony-arm64@0.27.7":
     optional: true
 
-  "@esbuild/sunos-x64@0.25.9":
-    optional: true
-
   "@esbuild/sunos-x64@0.27.7":
-    optional: true
-
-  "@esbuild/win32-arm64@0.25.9":
     optional: true
 
   "@esbuild/win32-arm64@0.27.7":
     optional: true
 
-  "@esbuild/win32-ia32@0.25.9":
-    optional: true
-
   "@esbuild/win32-ia32@0.27.7":
-    optional: true
-
-  "@esbuild/win32-x64@0.25.9":
     optional: true
 
   "@esbuild/win32-x64@0.27.7":
     optional: true
-
-  "@expressive-code/core@0.41.3":
-    dependencies:
-      "@ctrl/tinycolor": 4.1.0
-      hast-util-select: 6.0.4
-      hast-util-to-html: 9.0.5
-      hast-util-to-text: 4.0.2
-      hastscript: 9.0.1
-      postcss: 8.5.6
-      postcss-nested: 6.2.0(postcss@8.5.6)
-      unist-util-visit: 5.0.0
-      unist-util-visit-parents: 6.0.1
 
   "@expressive-code/core@0.41.7":
     dependencies:
@@ -7646,18 +6956,18 @@ snapshots:
     dependencies:
       "@expressive-code/core": 0.41.7
 
-  "@expressive-code/plugin-frames@0.41.3":
+  "@expressive-code/plugin-frames@0.41.7":
     dependencies:
-      "@expressive-code/core": 0.41.3
+      "@expressive-code/core": 0.41.7
 
-  "@expressive-code/plugin-shiki@0.41.3":
+  "@expressive-code/plugin-shiki@0.41.7":
     dependencies:
-      "@expressive-code/core": 0.41.3
+      "@expressive-code/core": 0.41.7
       shiki: 3.23.0
 
-  "@expressive-code/plugin-text-markers@0.41.3":
+  "@expressive-code/plugin-text-markers@0.41.7":
     dependencies:
-      "@expressive-code/core": 0.41.3
+      "@expressive-code/core": 0.41.7
 
   "@fortawesome/fontawesome-free@6.7.2": {}
 
@@ -7676,22 +6986,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@img/colour@1.1.0":
-    optional: true
-
-  "@img/sharp-darwin-arm64@0.33.5":
-    optionalDependencies:
-      "@img/sharp-libvips-darwin-arm64": 1.0.4
-    optional: true
+  "@img/colour@1.1.0": {}
 
   "@img/sharp-darwin-arm64@0.34.5":
     optionalDependencies:
       "@img/sharp-libvips-darwin-arm64": 1.2.4
-    optional: true
-
-  "@img/sharp-darwin-x64@0.33.5":
-    optionalDependencies:
-      "@img/sharp-libvips-darwin-x64": 1.0.4
     optional: true
 
   "@img/sharp-darwin-x64@0.34.5":
@@ -7699,25 +6998,13 @@ snapshots:
       "@img/sharp-libvips-darwin-x64": 1.2.4
     optional: true
 
-  "@img/sharp-libvips-darwin-arm64@1.0.4":
-    optional: true
-
   "@img/sharp-libvips-darwin-arm64@1.2.4":
-    optional: true
-
-  "@img/sharp-libvips-darwin-x64@1.0.4":
     optional: true
 
   "@img/sharp-libvips-darwin-x64@1.2.4":
     optional: true
 
-  "@img/sharp-libvips-linux-arm64@1.0.4":
-    optional: true
-
   "@img/sharp-libvips-linux-arm64@1.2.4":
-    optional: true
-
-  "@img/sharp-libvips-linux-arm@1.0.5":
     optional: true
 
   "@img/sharp-libvips-linux-arm@1.2.4":
@@ -7729,43 +7016,21 @@ snapshots:
   "@img/sharp-libvips-linux-riscv64@1.2.4":
     optional: true
 
-  "@img/sharp-libvips-linux-s390x@1.0.4":
-    optional: true
-
   "@img/sharp-libvips-linux-s390x@1.2.4":
-    optional: true
-
-  "@img/sharp-libvips-linux-x64@1.0.4":
     optional: true
 
   "@img/sharp-libvips-linux-x64@1.2.4":
     optional: true
 
-  "@img/sharp-libvips-linuxmusl-arm64@1.0.4":
-    optional: true
-
   "@img/sharp-libvips-linuxmusl-arm64@1.2.4":
-    optional: true
-
-  "@img/sharp-libvips-linuxmusl-x64@1.0.4":
     optional: true
 
   "@img/sharp-libvips-linuxmusl-x64@1.2.4":
     optional: true
 
-  "@img/sharp-linux-arm64@0.33.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-arm64": 1.0.4
-    optional: true
-
   "@img/sharp-linux-arm64@0.34.5":
     optionalDependencies:
       "@img/sharp-libvips-linux-arm64": 1.2.4
-    optional: true
-
-  "@img/sharp-linux-arm@0.33.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-arm": 1.0.5
     optional: true
 
   "@img/sharp-linux-arm@0.34.5":
@@ -7783,19 +7048,9 @@ snapshots:
       "@img/sharp-libvips-linux-riscv64": 1.2.4
     optional: true
 
-  "@img/sharp-linux-s390x@0.33.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-s390x": 1.0.4
-    optional: true
-
   "@img/sharp-linux-s390x@0.34.5":
     optionalDependencies:
       "@img/sharp-libvips-linux-s390x": 1.2.4
-    optional: true
-
-  "@img/sharp-linux-x64@0.33.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-x64": 1.0.4
     optional: true
 
   "@img/sharp-linux-x64@0.34.5":
@@ -7803,29 +7058,14 @@ snapshots:
       "@img/sharp-libvips-linux-x64": 1.2.4
     optional: true
 
-  "@img/sharp-linuxmusl-arm64@0.33.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linuxmusl-arm64": 1.0.4
-    optional: true
-
   "@img/sharp-linuxmusl-arm64@0.34.5":
     optionalDependencies:
       "@img/sharp-libvips-linuxmusl-arm64": 1.2.4
     optional: true
 
-  "@img/sharp-linuxmusl-x64@0.33.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linuxmusl-x64": 1.0.4
-    optional: true
-
   "@img/sharp-linuxmusl-x64@0.34.5":
     optionalDependencies:
       "@img/sharp-libvips-linuxmusl-x64": 1.2.4
-    optional: true
-
-  "@img/sharp-wasm32@0.33.5":
-    dependencies:
-      "@emnapi/runtime": 1.5.0
     optional: true
 
   "@img/sharp-wasm32@0.34.5":
@@ -7836,13 +7076,7 @@ snapshots:
   "@img/sharp-win32-arm64@0.34.5":
     optional: true
 
-  "@img/sharp-win32-ia32@0.33.5":
-    optional: true
-
   "@img/sharp-win32-ia32@0.34.5":
-    optional: true
-
-  "@img/sharp-win32-x64@0.33.5":
     optional: true
 
   "@img/sharp-win32-x64@0.34.5":
@@ -7873,7 +7107,7 @@ snapshots:
       "@types/estree-jsx": 1.0.5
       "@types/hast": 3.0.4
       "@types/mdx": 2.0.13
-      acorn: 8.15.0
+      acorn: 8.16.0
       collapse-white-space: 2.1.0
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
@@ -7882,7 +7116,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.1(acorn@8.15.0)
+      recma-jsx: 1.0.1(acorn@8.16.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.1.1
@@ -7892,7 +7126,7 @@ snapshots:
       unified: 11.0.5
       unist-util-position-from-estree: 2.0.0
       unist-util-stringify-position: 4.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -7900,18 +7134,6 @@ snapshots:
   "@mermaid-js/parser@0.6.2":
     dependencies:
       langium: 3.3.1
-
-  "@nodelib/fs.scandir@2.1.5":
-    dependencies:
-      "@nodelib/fs.stat": 2.0.5
-      run-parallel: 1.2.0
-
-  "@nodelib/fs.stat@2.0.5": {}
-
-  "@nodelib/fs.walk@1.2.8":
-    dependencies:
-      "@nodelib/fs.scandir": 2.1.5
-      fastq: 1.19.1
 
   "@octokit/app@16.1.2":
     dependencies:
@@ -8083,7 +7305,7 @@ snapshots:
   "@pagefind/windows-x64@1.4.0":
     optional: true
 
-  "@qwik.dev/partytown@0.11.2":
+  "@qwik.dev/partytown@0.13.2":
     dependencies:
       dotenv: 16.6.1
 
@@ -8091,7 +7313,7 @@ snapshots:
     dependencies:
       "@types/estree": 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.50.1
 
@@ -8165,9 +7387,23 @@ snapshots:
       "@types/hast": 3.0.4
       hast-util-to-html: 9.0.5
 
+  "@shikijs/core@4.0.2":
+    dependencies:
+      "@shikijs/primitive": 4.0.2
+      "@shikijs/types": 4.0.2
+      "@shikijs/vscode-textmate": 10.0.2
+      "@types/hast": 3.0.4
+      hast-util-to-html: 9.0.5
+
   "@shikijs/engine-javascript@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
+      "@shikijs/vscode-textmate": 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  "@shikijs/engine-javascript@4.0.2":
+    dependencies:
+      "@shikijs/types": 4.0.2
       "@shikijs/vscode-textmate": 10.0.2
       oniguruma-to-es: 4.3.6
 
@@ -8176,15 +7412,39 @@ snapshots:
       "@shikijs/types": 3.23.0
       "@shikijs/vscode-textmate": 10.0.2
 
+  "@shikijs/engine-oniguruma@4.0.2":
+    dependencies:
+      "@shikijs/types": 4.0.2
+      "@shikijs/vscode-textmate": 10.0.2
+
   "@shikijs/langs@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
+
+  "@shikijs/langs@4.0.2":
+    dependencies:
+      "@shikijs/types": 4.0.2
+
+  "@shikijs/primitive@4.0.2":
+    dependencies:
+      "@shikijs/types": 4.0.2
+      "@shikijs/vscode-textmate": 10.0.2
+      "@types/hast": 3.0.4
 
   "@shikijs/themes@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
 
+  "@shikijs/themes@4.0.2":
+    dependencies:
+      "@shikijs/types": 4.0.2
+
   "@shikijs/types@3.23.0":
+    dependencies:
+      "@shikijs/vscode-textmate": 10.0.2
+      "@types/hast": 3.0.4
+
+  "@shikijs/types@4.0.2":
     dependencies:
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
@@ -8193,9 +7453,11 @@ snapshots:
 
   "@sindresorhus/is@4.6.0": {}
 
-  "@sveltejs/acorn-typescript@1.0.5(acorn@8.15.0)":
+  "@standard-schema/spec@1.1.0": {}
+
+  "@sveltejs/acorn-typescript@1.0.5(acorn@8.16.0)":
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
 
   "@tailwindcss/node@4.2.4":
     dependencies:
@@ -8258,12 +7520,12 @@ snapshots:
       "@tailwindcss/oxide-win32-arm64-msvc": 4.2.4
       "@tailwindcss/oxide-win32-x64-msvc": 4.2.4
 
-  "@tailwindcss/vite@4.2.4(vite@6.4.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))":
+  "@tailwindcss/vite@4.2.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))":
     dependencies:
       "@tailwindcss/node": 4.2.4
       "@tailwindcss/oxide": 4.2.4
       tailwindcss: 4.2.4
-      vite: 6.4.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1)
+      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
 
   "@types/aws-lambda@8.10.161": {}
 
@@ -8421,17 +7683,20 @@ snapshots:
     dependencies:
       "@types/unist": 3.0.3
 
-  "@types/node@17.0.45": {}
+  "@types/node@24.12.2":
+    dependencies:
+      undici-types: 7.16.0
 
   "@types/node@24.3.1":
     dependencies:
       undici-types: 7.10.0
+    optional: true
 
-  "@types/picomatch@3.0.2": {}
+  "@types/picomatch@4.0.3": {}
 
   "@types/sax@1.2.7":
     dependencies:
-      "@types/node": 24.3.1
+      "@types/node": 24.12.2
 
   "@types/trusted-types@2.0.7":
     optional: true
@@ -8447,66 +7712,65 @@ snapshots:
 
   "@ungap/structured-clone@1.3.0": {}
 
-  "@vitest/expect@3.2.4":
+  "@vitest/expect@4.1.5":
     dependencies:
+      "@standard-schema/spec": 1.1.0
       "@types/chai": 5.2.3
-      "@vitest/spy": 3.2.4
-      "@vitest/utils": 3.2.4
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
+      "@vitest/spy": 4.1.5
+      "@vitest/utils": 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
 
-  "@vitest/mocker@3.2.4(vite@6.4.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))":
+  "@vitest/mocker@4.1.5(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))":
     dependencies:
-      "@vitest/spy": 3.2.4
+      "@vitest/spy": 4.1.5
       estree-walker: 3.0.3
-      magic-string: 0.30.19
+      magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1)
+      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
 
-  "@vitest/pretty-format@3.2.4":
+  "@vitest/pretty-format@4.1.5":
     dependencies:
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
 
-  "@vitest/runner@3.2.4":
+  "@vitest/runner@4.1.5":
     dependencies:
-      "@vitest/utils": 3.2.4
-      pathe: 2.0.3
-      strip-literal: 3.1.0
-
-  "@vitest/snapshot@3.2.4":
-    dependencies:
-      "@vitest/pretty-format": 3.2.4
-      magic-string: 0.30.19
+      "@vitest/utils": 4.1.5
       pathe: 2.0.3
 
-  "@vitest/spy@3.2.4":
+  "@vitest/snapshot@4.1.5":
     dependencies:
-      tinyspy: 4.0.4
+      "@vitest/pretty-format": 4.1.5
+      "@vitest/utils": 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
 
-  "@vitest/utils@3.2.4":
-    dependencies:
-      "@vitest/pretty-format": 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
+  "@vitest/spy@4.1.5": {}
 
-  "@volar/kit@2.4.23(typescript@5.9.2)":
+  "@vitest/utils@4.1.5":
     dependencies:
-      "@volar/language-service": 2.4.23
-      "@volar/typescript": 2.4.23
+      "@vitest/pretty-format": 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  "@volar/kit@2.4.28(typescript@5.9.2)":
+    dependencies:
+      "@volar/language-service": 2.4.28
+      "@volar/typescript": 2.4.28
       typesafe-path: 0.2.2
       typescript: 5.9.2
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
-  "@volar/language-core@2.4.23":
+  "@volar/language-core@2.4.28":
     dependencies:
-      "@volar/source-map": 2.4.23
+      "@volar/source-map": 2.4.28
 
-  "@volar/language-server@2.4.23":
+  "@volar/language-server@2.4.28":
     dependencies:
-      "@volar/language-core": 2.4.23
-      "@volar/language-service": 2.4.23
-      "@volar/typescript": 2.4.23
+      "@volar/language-core": 2.4.28
+      "@volar/language-service": 2.4.28
+      "@volar/typescript": 2.4.28
       path-browserify: 1.0.1
       request-light: 0.7.0
       vscode-languageserver: 9.0.1
@@ -8514,18 +7778,18 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
-  "@volar/language-service@2.4.23":
+  "@volar/language-service@2.4.28":
     dependencies:
-      "@volar/language-core": 2.4.23
+      "@volar/language-core": 2.4.28
       vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
-  "@volar/source-map@2.4.23": {}
+  "@volar/source-map@2.4.28": {}
 
-  "@volar/typescript@2.4.23":
+  "@volar/typescript@2.4.28":
     dependencies:
-      "@volar/language-core": 2.4.23
+      "@volar/language-core": 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
@@ -8539,11 +7803,13 @@ snapshots:
 
   "@vscode/l10n@0.0.18": {}
 
-  acorn-jsx@5.3.2(acorn@8.15.0):
+  acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
 
   acorn@8.15.0: {}
+
+  acorn@8.16.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -8551,16 +7817,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ajv-draft-04@1.0.0(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-
-  ansi-align@3.0.1:
-    dependencies:
-      string-width: 4.2.3
 
   ansi-escapes@7.0.0:
     dependencies:
@@ -8607,76 +7873,67 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  astro-expressive-code@0.41.3(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1)):
+  astro-expressive-code@0.41.7(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3)):
     dependencies:
-      astro: 5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1)
-      rehype-expressive-code: 0.41.3
+      astro: 6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3)
+      rehype-expressive-code: 0.41.7
 
-  astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1):
+  astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3):
     dependencies:
-      "@astrojs/compiler": 2.13.1
-      "@astrojs/internal-helpers": 0.7.6
-      "@astrojs/markdown-remark": 6.3.11
-      "@astrojs/telemetry": 3.3.0
+      "@astrojs/compiler": 3.0.1
+      "@astrojs/internal-helpers": 0.9.0
+      "@astrojs/markdown-remark": 7.1.1
+      "@astrojs/telemetry": 3.3.1
       "@capsizecss/unpack": 4.0.0
+      "@clack/prompts": 1.2.0
       "@oslojs/encoding": 1.1.0
       "@rollup/pluginutils": 5.3.0(rollup@4.50.1)
-      acorn: 8.15.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
-      boxen: 8.0.1
       ci-info: 4.4.0
       clsx: 2.1.1
-      common-ancestor-path: 1.0.1
+      common-ancestor-path: 2.0.0
       cookie: 1.1.1
-      cssesc: 3.0.0
-      debug: 4.4.3
-      deterministic-object-hash: 2.0.2
       devalue: 5.7.1
       diff: 8.0.4
-      dlv: 1.1.3
       dset: 3.1.4
-      es-module-lexer: 1.7.0
+      es-module-lexer: 2.1.0
       esbuild: 0.27.7
-      estree-walker: 3.0.3
       flattie: 1.1.1
       fontace: 0.4.1
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      import-meta-resolve: 4.2.0
       js-yaml: 4.1.1
       magic-string: 0.30.21
       magicast: 0.5.2
       mrmime: 2.0.1
       neotraverse: 0.6.18
-      p-limit: 6.2.0
-      p-queue: 8.1.1
+      obug: 2.1.1
+      p-limit: 7.3.0
+      p-queue: 9.1.2
       package-manager-detector: 1.6.0
       piccolore: 0.1.3
-      picomatch: 4.0.3
-      prompts: 2.4.2
+      picomatch: 4.0.4
       rehype: 13.0.2
       semver: 7.7.4
-      shiki: 3.23.0
+      shiki: 4.0.2
       smol-toml: 1.6.1
       svgo: 4.0.1
+      tinyclip: 0.1.12
       tinyexec: 1.1.1
       tinyglobby: 0.2.15
       tsconfck: 3.1.6(typescript@5.9.2)
       ultrahtml: 1.6.0
       unifont: 0.7.4
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 6.4.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1)
-      vitefu: 1.1.1(vite@6.4.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))
+      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vitefu: 1.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
       xxhash-wasm: 1.1.0
-      yargs-parser: 21.1.1
-      yocto-spinner: 0.2.3
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
-      zod-to-ts: 1.2.0(typescript@5.9.2)(zod@3.25.76)
+      yargs-parser: 22.0.0
+      zod: 4.3.6
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -8754,8 +8011,6 @@ snapshots:
     dependencies:
       bare-path: 3.0.0
 
-  base-64@1.0.0: {}
-
   base64-js@1.5.1: {}
 
   bcp-47-match@2.0.3: {}
@@ -8771,17 +8026,6 @@ snapshots:
   boolbase@1.0.0: {}
 
   bottleneck@2.19.5: {}
-
-  boxen@8.0.1:
-    dependencies:
-      ansi-align: 3.0.1
-      camelcase: 8.0.0
-      chalk: 5.6.2
-      cli-boxes: 3.0.0
-      string-width: 7.2.0
-      type-fest: 4.41.0
-      widest-line: 5.0.0
-      wrap-ansi: 9.0.2
 
   brace-expansion@1.1.12:
     dependencies:
@@ -8799,19 +8043,9 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  cac@6.7.14: {}
-
-  camelcase@8.0.0: {}
-
   ccount@2.0.1: {}
 
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.1
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
+  chai@6.2.2: {}
 
   chalk@5.6.2: {}
 
@@ -8824,8 +8058,6 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
-
-  check-error@2.1.1: {}
 
   chevrotain-allstar@0.3.1(chevrotain@11.0.3):
     dependencies:
@@ -8850,8 +8082,6 @@ snapshots:
       readdirp: 5.0.0
 
   ci-info@4.4.0: {}
-
-  cli-boxes@3.0.0: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -8878,16 +8108,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  color-string@1.9.1:
-    dependencies:
-      color-name: 1.1.4
-      simple-swizzle: 0.2.2
-
-  color@4.2.3:
-    dependencies:
-      color-convert: 2.0.1
-      color-string: 1.9.1
-
   colorette@2.0.20: {}
 
   comma-separated-tokens@2.0.3: {}
@@ -8900,13 +8120,15 @@ snapshots:
 
   commander@8.3.0: {}
 
-  common-ancestor-path@1.0.1: {}
+  common-ancestor-path@2.0.0: {}
 
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
 
   confbox@0.2.2: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-es@1.2.3: {}
 
@@ -9158,15 +8380,9 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
   decode-named-character-reference@1.2.0:
     dependencies:
       character-entities: 2.0.2
-
-  deep-eql@5.0.2: {}
 
   defu@6.1.7: {}
 
@@ -9178,14 +8394,7 @@ snapshots:
 
   destr@2.0.5: {}
 
-  detect-libc@2.0.4: {}
-
-  detect-libc@2.1.2:
-    optional: true
-
-  deterministic-object-hash@2.0.2:
-    dependencies:
-      base-64: 1.0.0
+  detect-libc@2.1.2: {}
 
   devalue@5.7.1: {}
 
@@ -9255,7 +8464,7 @@ snapshots:
 
   environment@1.1.0: {}
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.1.0: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -9267,38 +8476,9 @@ snapshots:
   esast-util-from-js@2.0.1:
     dependencies:
       "@types/estree-jsx": 1.0.5
-      acorn: 8.15.0
+      acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
-
-  esbuild@0.25.9:
-    optionalDependencies:
-      "@esbuild/aix-ppc64": 0.25.9
-      "@esbuild/android-arm": 0.25.9
-      "@esbuild/android-arm64": 0.25.9
-      "@esbuild/android-x64": 0.25.9
-      "@esbuild/darwin-arm64": 0.25.9
-      "@esbuild/darwin-x64": 0.25.9
-      "@esbuild/freebsd-arm64": 0.25.9
-      "@esbuild/freebsd-x64": 0.25.9
-      "@esbuild/linux-arm": 0.25.9
-      "@esbuild/linux-arm64": 0.25.9
-      "@esbuild/linux-ia32": 0.25.9
-      "@esbuild/linux-loong64": 0.25.9
-      "@esbuild/linux-mips64el": 0.25.9
-      "@esbuild/linux-ppc64": 0.25.9
-      "@esbuild/linux-riscv64": 0.25.9
-      "@esbuild/linux-s390x": 0.25.9
-      "@esbuild/linux-x64": 0.25.9
-      "@esbuild/netbsd-arm64": 0.25.9
-      "@esbuild/netbsd-x64": 0.25.9
-      "@esbuild/openbsd-arm64": 0.25.9
-      "@esbuild/openbsd-x64": 0.25.9
-      "@esbuild/openharmony-arm64": 0.25.9
-      "@esbuild/sunos-x64": 0.25.9
-      "@esbuild/win32-arm64": 0.25.9
-      "@esbuild/win32-ia32": 0.25.9
-      "@esbuild/win32-x64": 0.25.9
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -9394,14 +8574,14 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
-  expect-type@1.2.2: {}
+  expect-type@1.3.0: {}
 
-  expressive-code@0.41.3:
+  expressive-code@0.41.7:
     dependencies:
-      "@expressive-code/core": 0.41.3
-      "@expressive-code/plugin-frames": 0.41.3
-      "@expressive-code/plugin-shiki": 0.41.3
-      "@expressive-code/plugin-text-markers": 0.41.3
+      "@expressive-code/core": 0.41.7
+      "@expressive-code/plugin-frames": 0.41.7
+      "@expressive-code/plugin-shiki": 0.41.7
+      "@expressive-code/plugin-text-markers": 0.41.7
 
   exsolve@1.0.7: {}
 
@@ -9423,19 +8603,17 @@ snapshots:
 
   fast-fifo@1.3.2: {}
 
-  fast-glob@3.3.3:
+  fast-string-truncated-width@1.2.1: {}
+
+  fast-string-width@1.1.0:
     dependencies:
-      "@nodelib/fs.stat": 2.0.5
-      "@nodelib/fs.walk": 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
+      fast-string-truncated-width: 1.2.1
 
   fast-uri@3.1.0: {}
 
-  fastq@1.19.1:
+  fast-wrap-ansi@0.1.6:
     dependencies:
-      reusify: 1.1.0
+      fast-string-width: 1.1.0
 
   fd-slicer@1.1.0:
     dependencies:
@@ -9444,6 +8622,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fill-range@7.1.1:
     dependencies:
@@ -9479,10 +8661,6 @@ snapshots:
 
   github-slugger@2.0.0: {}
 
-  glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
-
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -9510,6 +8688,8 @@ snapshots:
 
   hachure-fill@0.5.2: {}
 
+  has-flag@5.0.1: {}
+
   hast-util-embedded@3.0.0:
     dependencies:
       "@types/hast": 3.0.4
@@ -9523,7 +8703,7 @@ snapshots:
       hast-util-phrasing: 3.0.1
       hast-util-whitespace: 3.0.0
       html-whitespace-sensitive-tag-names: 3.0.1
-      unist-util-visit-parents: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   hast-util-from-dom@5.0.1:
     dependencies:
@@ -9601,7 +8781,7 @@ snapshots:
       mdast-util-to-hast: 13.2.0
       parse5: 7.3.0
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
       web-namespaces: 2.0.1
       zwitch: 2.0.4
@@ -9741,8 +8921,6 @@ snapshots:
 
   ieee754@1.2.1: {}
 
-  import-meta-resolve@4.2.0: {}
-
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -9758,7 +8936,7 @@ snapshots:
 
   iron-webcrypto@1.2.1: {}
 
-  is-absolute-url@4.0.1: {}
+  is-absolute-url@5.0.0: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -9767,13 +8945,11 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
-  is-arrayish@0.3.2: {}
-
   is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
 
-  is-extglob@2.1.1: {}
+  is-docker@4.0.0: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -9782,10 +8958,6 @@ snapshots:
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.3.1
-
-  is-glob@4.0.3:
-    dependencies:
-      is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
 
@@ -9803,19 +8975,13 @@ snapshots:
 
   is-stream@3.0.0: {}
 
-  is-wsl@3.1.0:
+  is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
 
   jiti@2.6.1: {}
-
-  js-tokens@9.0.1: {}
-
-  js-yaml@4.1.0:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.1.1:
     dependencies:
@@ -9834,8 +9000,6 @@ snapshots:
       commander: 8.3.0
 
   khroma@2.1.0: {}
-
-  kleur@3.0.3: {}
 
   kleur@4.1.5: {}
 
@@ -9890,7 +9054,7 @@ snapshots:
 
   lightningcss@1.32.0:
     dependencies:
-      detect-libc: 2.0.4
+      detect-libc: 2.1.2
     optionalDependencies:
       lightningcss-android-arm64: 1.32.0
       lightningcss-darwin-arm64: 1.32.0
@@ -9930,7 +9094,7 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
-  lite-youtube-embed@0.3.3: {}
+  lite-youtube-embed@0.3.4: {}
 
   local-pkg@1.1.2:
     dependencies:
@@ -9942,8 +9106,6 @@ snapshots:
 
   lodash-es@4.17.21: {}
 
-  lodash@4.17.21: {}
-
   log-update@6.1.0:
     dependencies:
       ansi-escapes: 7.0.0
@@ -9954,13 +9116,7 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
-  loupe@3.2.1: {}
-
   lru-cache@11.3.5: {}
-
-  magic-string@0.30.19:
-    dependencies:
-      "@jridgewell/sourcemap-codec": 1.5.5
 
   magic-string@0.30.21:
     dependencies:
@@ -9984,7 +9140,7 @@ snapshots:
     dependencies:
       "@types/mdast": 4.0.4
       "@types/unist": 3.0.3
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   mdast-util-directive@3.1.0:
     dependencies:
@@ -9996,7 +9152,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
-      unist-util-visit-parents: 6.0.1
+      unist-util-visit-parents: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -10147,6 +9303,18 @@ snapshots:
       unist-util-visit: 5.0.0
       vfile: 6.0.3
 
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      "@types/hast": 3.0.4
+      "@types/mdast": 4.0.4
+      "@ungap/structured-clone": 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
   mdast-util-to-markdown@2.1.2:
     dependencies:
       "@types/mdast": 4.0.4
@@ -10168,8 +9336,6 @@ snapshots:
   mdn-data@2.12.2: {}
 
   merge-stream@2.0.0: {}
-
-  merge2@1.4.1: {}
 
   mermaid-isomorphic@3.0.4(playwright@1.59.1):
     dependencies:
@@ -10334,8 +9500,8 @@ snapshots:
 
   micromark-extension-mdxjs@3.0.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       micromark-extension-mdx-expression: 3.0.1
       micromark-extension-mdx-jsx: 3.0.2
       micromark-extension-mdx-md: 2.0.0
@@ -10550,6 +9716,8 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  obug@2.1.1: {}
+
   octokit@5.0.5:
     dependencies:
       "@octokit/app": 16.1.2
@@ -10568,7 +9736,7 @@ snapshots:
     dependencies:
       destr: 2.0.5
       node-fetch-native: 1.6.7
-      ufo: 1.6.1
+      ufo: 1.6.3
 
   ohash@2.0.11: {}
 
@@ -10592,16 +9760,16 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  p-limit@6.2.0:
+  p-limit@7.3.0:
     dependencies:
       yocto-queue: 1.2.1
 
-  p-queue@8.1.1:
+  p-queue@9.1.2:
     dependencies:
       eventemitter3: 5.0.1
-      p-timeout: 6.1.4
+      p-timeout: 7.0.1
 
-  p-timeout@6.1.4: {}
+  p-timeout@7.0.1: {}
 
   package-manager-detector@1.3.0: {}
 
@@ -10651,8 +9819,6 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pathval@2.0.1: {}
-
   pend@1.2.0: {}
 
   piccolore@0.1.3: {}
@@ -10662,6 +9828,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  picomatch@4.0.4: {}
 
   pidtree@0.6.0: {}
 
@@ -10702,6 +9870,12 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
+  postcss@8.5.12:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -10732,19 +9906,13 @@ snapshots:
       prettier-plugin-organize-imports: 4.2.0(prettier@3.4.2)(typescript@5.9.2)
       prettier-plugin-svelte: 3.4.0(prettier@3.4.2)(svelte@5.38.7)
 
-  prettier@2.8.7:
-    optional: true
-
   prettier@3.4.2: {}
+
+  prettier@3.8.3: {}
 
   prismjs@1.30.0: {}
 
   progress@2.0.3: {}
-
-  prompts@2.4.2:
-    dependencies:
-      kleur: 3.0.3
-      sisteransi: 1.0.5
 
   property-information@6.5.0: {}
 
@@ -10795,8 +9963,6 @@ snapshots:
 
   quansync@0.2.11: {}
 
-  queue-microtask@1.2.3: {}
-
   radix3@1.1.2: {}
 
   readdirp@4.1.2: {}
@@ -10809,10 +9975,10 @@ snapshots:
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.1(acorn@8.15.0):
+  recma-jsx@1.0.1(acorn@8.16.0):
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0
@@ -10842,9 +10008,9 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
-  rehype-expressive-code@0.41.3:
+  rehype-expressive-code@0.41.7:
     dependencies:
-      expressive-code: 0.41.3
+      expressive-code: 0.41.7
 
   rehype-format@5.0.1:
     dependencies:
@@ -10963,7 +10129,7 @@ snapshots:
       retext: 9.0.0
       retext-smartypants: 6.2.0
       unified: 11.0.5
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   remark-stringify@11.0.0:
     dependencies:
@@ -11012,7 +10178,7 @@ snapshots:
     dependencies:
       "@types/nlcst": 2.0.3
       nlcst-to-string: 4.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   retext-stringify@4.0.0:
     dependencies:
@@ -11026,8 +10192,6 @@ snapshots:
       retext-latin: 4.0.0
       retext-stringify: 4.0.0
       unified: 11.0.5
-
-  reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
 
@@ -11071,10 +10235,6 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
-  run-parallel@1.2.0:
-    dependencies:
-      queue-microtask: 1.2.3
-
   rw@1.3.3: {}
 
   s.color@0.0.15: {}
@@ -11085,39 +10245,9 @@ snapshots:
     dependencies:
       suf-log: 2.5.3
 
-  sax@1.4.1: {}
-
   sax@1.6.0: {}
 
-  semver@7.7.2: {}
-
   semver@7.7.4: {}
-
-  sharp@0.33.5:
-    dependencies:
-      color: 4.2.3
-      detect-libc: 2.0.4
-      semver: 7.7.2
-    optionalDependencies:
-      "@img/sharp-darwin-arm64": 0.33.5
-      "@img/sharp-darwin-x64": 0.33.5
-      "@img/sharp-libvips-darwin-arm64": 1.0.4
-      "@img/sharp-libvips-darwin-x64": 1.0.4
-      "@img/sharp-libvips-linux-arm": 1.0.5
-      "@img/sharp-libvips-linux-arm64": 1.0.4
-      "@img/sharp-libvips-linux-s390x": 1.0.4
-      "@img/sharp-libvips-linux-x64": 1.0.4
-      "@img/sharp-libvips-linuxmusl-arm64": 1.0.4
-      "@img/sharp-libvips-linuxmusl-x64": 1.0.4
-      "@img/sharp-linux-arm": 0.33.5
-      "@img/sharp-linux-arm64": 0.33.5
-      "@img/sharp-linux-s390x": 0.33.5
-      "@img/sharp-linux-x64": 0.33.5
-      "@img/sharp-linuxmusl-arm64": 0.33.5
-      "@img/sharp-linuxmusl-x64": 0.33.5
-      "@img/sharp-wasm32": 0.33.5
-      "@img/sharp-win32-ia32": 0.33.5
-      "@img/sharp-win32-x64": 0.33.5
 
   sharp@0.34.5:
     dependencies:
@@ -11149,7 +10279,6 @@ snapshots:
       "@img/sharp-win32-arm64": 0.34.5
       "@img/sharp-win32-ia32": 0.34.5
       "@img/sharp-win32-x64": 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -11168,22 +10297,29 @@ snapshots:
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
 
+  shiki@4.0.2:
+    dependencies:
+      "@shikijs/core": 4.0.2
+      "@shikijs/engine-javascript": 4.0.2
+      "@shikijs/engine-oniguruma": 4.0.2
+      "@shikijs/langs": 4.0.2
+      "@shikijs/themes": 4.0.2
+      "@shikijs/types": 4.0.2
+      "@shikijs/vscode-textmate": 10.0.2
+      "@types/hast": 3.0.4
+
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
 
-  simple-swizzle@0.2.2:
-    dependencies:
-      is-arrayish: 0.3.2
-
   sisteransi@1.0.5: {}
 
-  sitemap@8.0.0:
+  sitemap@9.0.1:
     dependencies:
-      "@types/node": 17.0.45
+      "@types/node": 24.12.2
       "@types/sax": 1.2.7
       arg: 5.0.2
-      sax: 1.4.1
+      sax: 1.6.0
 
   skin-tone@2.0.0:
     dependencies:
@@ -11199,8 +10335,6 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  smol-toml@1.4.2: {}
-
   smol-toml@1.6.1: {}
 
   source-map-js@1.2.1: {}
@@ -11211,25 +10345,29 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-auto-sidebar@0.1.4(@astrojs/starlight@0.36.3(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1))):
+  starlight-auto-sidebar@0.3.0(@astrojs/starlight@0.38.4(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3))):
     dependencies:
-      "@astrojs/starlight": 0.36.3(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1))
+      "@astrojs/starlight": 0.38.4(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3))
       github-slugger: 2.0.0
 
-  starlight-links-validator@0.14.1(@astrojs/starlight@0.36.3(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1))):
+  starlight-links-validator@0.23.0(@astrojs/starlight@0.38.4(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3)))(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3)):
     dependencies:
-      "@astrojs/starlight": 0.36.3(astro@5.18.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1))
-      "@types/picomatch": 3.0.2
+      "@astrojs/starlight": 0.38.4(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3))
+      "@types/picomatch": 4.0.3
+      astro: 6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.3)
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
-      hast-util-has-property: 3.0.0
-      is-absolute-url: 4.0.1
-      kleur: 4.1.5
-      mdast-util-to-string: 4.0.0
-      picomatch: 4.0.3
-      unist-util-visit: 5.0.0
+      is-absolute-url: 5.0.0
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-to-hast: 13.2.1
+      picomatch: 4.0.4
+      terminal-link: 5.0.0
+      unist-util-visit: 5.1.0
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
 
-  std-env@3.9.0: {}
+  std-env@4.1.0: {}
 
   stream-replace-string@2.0.0: {}
 
@@ -11271,10 +10409,6 @@ snapshots:
 
   strip-final-newline@3.0.0: {}
 
-  strip-literal@3.1.0:
-    dependencies:
-      js-tokens: 9.0.1
-
   style-to-js@1.1.17:
     dependencies:
       style-to-object: 1.0.9
@@ -11289,13 +10423,20 @@ snapshots:
     dependencies:
       s.color: 0.0.15
 
+  supports-color@10.2.2: {}
+
+  supports-hyperlinks@4.4.0:
+    dependencies:
+      has-flag: 5.0.1
+      supports-color: 10.2.2
+
   svelte@5.38.7:
     dependencies:
       "@jridgewell/remapping": 2.3.5
       "@jridgewell/sourcemap-codec": 1.5.5
-      "@sveltejs/acorn-typescript": 1.0.5(acorn@8.15.0)
+      "@sveltejs/acorn-typescript": 1.0.5(acorn@8.16.0)
       "@types/estree": 1.0.8
-      acorn: 8.15.0
+      acorn: 8.16.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
       clsx: 2.1.1
@@ -11354,6 +10495,11 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  terminal-link@5.0.0:
+    dependencies:
+      ansi-escapes: 7.0.0
+      supports-hyperlinks: 4.4.0
+
   text-decoder@1.2.7:
     dependencies:
       b4a: 1.8.0
@@ -11366,7 +10512,7 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.2: {}
+  tinyclip@0.1.12: {}
 
   tinyexec@1.0.1: {}
 
@@ -11377,11 +10523,12 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tinypool@1.1.1: {}
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
-  tinyrainbow@2.0.0: {}
-
-  tinyspy@4.0.4: {}
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -11418,13 +10565,11 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  type-fest@4.41.0: {}
-
   typesafe-path@0.2.2: {}
 
   typescript-auto-import-cache@0.3.6:
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.4
 
   typescript@5.9.2: {}
 
@@ -11441,7 +10586,10 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
-  undici-types@7.10.0: {}
+  undici-types@7.10.0:
+    optional: true
+
+  undici-types@7.16.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 
@@ -11527,6 +10675,12 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
+  unist-util-visit@5.1.0:
+    dependencies:
+      "@types/unist": 3.0.3
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.2
+
   universal-github-app-jwt@2.2.2: {}
 
   universal-user-agent@7.0.3: {}
@@ -11563,143 +10717,107 @@ snapshots:
       "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1):
+  vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
     dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 6.4.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1)
-    transitivePeerDependencies:
-      - "@types/node"
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vite@6.4.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1):
-    dependencies:
-      esbuild: 0.25.9
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.12
       rollup: 4.50.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     optionalDependencies:
-      "@types/node": 24.3.1
+      "@types/node": 24.12.2
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
-      yaml: 2.8.1
+      yaml: 2.8.3
 
-  vitefu@1.1.1(vite@6.4.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1)):
+  vitefu@1.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1)
+      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1):
+  vitest@4.1.5(@types/node@24.12.2)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)):
     dependencies:
-      "@types/chai": 5.2.3
-      "@vitest/expect": 3.2.4
-      "@vitest/mocker": 3.2.4(vite@6.4.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))
-      "@vitest/pretty-format": 3.2.4
-      "@vitest/runner": 3.2.4
-      "@vitest/snapshot": 3.2.4
-      "@vitest/spy": 3.2.4
-      "@vitest/utils": 3.2.4
-      chai: 5.3.3
-      debug: 4.4.1
-      expect-type: 1.2.2
-      magic-string: 0.30.19
+      "@vitest/expect": 4.1.5
+      "@vitest/mocker": 4.1.5(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      "@vitest/pretty-format": 4.1.5
+      "@vitest/runner": 4.1.5
+      "@vitest/snapshot": 4.1.5
+      "@vitest/spy": 4.1.5
+      "@vitest/utils": 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.9.0
+      picomatch: 4.0.4
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1)
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      "@types/debug": 4.1.12
-      "@types/node": 24.3.1
+      "@types/node": 24.12.2
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
-  volar-service-css@0.0.62(@volar/language-service@2.4.23):
+  volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-css-languageservice: 6.3.7
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
     optionalDependencies:
-      "@volar/language-service": 2.4.23
+      "@volar/language-service": 2.4.28
 
-  volar-service-emmet@0.0.62(@volar/language-service@2.4.23):
+  volar-service-emmet@0.0.70(@volar/language-service@2.4.28):
     dependencies:
-      "@emmetio/css-parser": 0.4.0
+      "@emmetio/css-parser": 0.4.1
       "@emmetio/html-matcher": 1.3.0
       "@vscode/emmet-helper": 2.11.0
       vscode-uri: 3.1.0
     optionalDependencies:
-      "@volar/language-service": 2.4.23
+      "@volar/language-service": 2.4.28
 
-  volar-service-html@0.0.62(@volar/language-service@2.4.23):
+  volar-service-html@0.0.70(@volar/language-service@2.4.28):
     dependencies:
-      vscode-html-languageservice: 5.5.1
+      vscode-html-languageservice: 5.6.2
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
     optionalDependencies:
-      "@volar/language-service": 2.4.23
+      "@volar/language-service": 2.4.28
 
-  volar-service-prettier@0.0.62(@volar/language-service@2.4.23)(prettier@3.4.2):
+  volar-service-prettier@0.0.70(@volar/language-service@2.4.28)(prettier@3.4.2):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
-      "@volar/language-service": 2.4.23
+      "@volar/language-service": 2.4.28
       prettier: 3.4.2
 
-  volar-service-typescript-twoslash-queries@0.0.62(@volar/language-service@2.4.23):
+  volar-service-typescript-twoslash-queries@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
-      "@volar/language-service": 2.4.23
+      "@volar/language-service": 2.4.28
 
-  volar-service-typescript@0.0.62(@volar/language-service@2.4.23):
+  volar-service-typescript@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       path-browserify: 1.0.1
-      semver: 7.7.2
+      semver: 7.7.4
       typescript-auto-import-cache: 0.3.6
       vscode-languageserver-textdocument: 1.0.12
       vscode-nls: 5.2.0
       vscode-uri: 3.1.0
     optionalDependencies:
-      "@volar/language-service": 2.4.23
+      "@volar/language-service": 2.4.28
 
-  volar-service-yaml@0.0.62(@volar/language-service@2.4.23):
+  volar-service-yaml@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-uri: 3.1.0
-      yaml-language-server: 1.15.0
+      yaml-language-server: 1.20.0
     optionalDependencies:
-      "@volar/language-service": 2.4.23
+      "@volar/language-service": 2.4.28
 
   vscode-css-languageservice@6.3.7:
     dependencies:
@@ -11708,7 +10826,7 @@ snapshots:
       vscode-languageserver-types: 3.17.5
       vscode-uri: 3.1.0
 
-  vscode-html-languageservice@5.5.1:
+  vscode-html-languageservice@5.6.2:
     dependencies:
       "@vscode/l10n": 0.0.18
       vscode-languageserver-textdocument: 1.0.12
@@ -11723,14 +10841,7 @@ snapshots:
       vscode-nls: 5.2.0
       vscode-uri: 3.1.0
 
-  vscode-jsonrpc@6.0.0: {}
-
   vscode-jsonrpc@8.2.0: {}
-
-  vscode-languageserver-protocol@3.16.0:
-    dependencies:
-      vscode-jsonrpc: 6.0.0
-      vscode-languageserver-types: 3.16.0
 
   vscode-languageserver-protocol@3.17.5:
     dependencies:
@@ -11739,13 +10850,7 @@ snapshots:
 
   vscode-languageserver-textdocument@1.0.12: {}
 
-  vscode-languageserver-types@3.16.0: {}
-
   vscode-languageserver-types@3.17.5: {}
-
-  vscode-languageserver@7.0.0:
-    dependencies:
-      vscode-languageserver-protocol: 3.16.0
 
   vscode-languageserver@9.0.1:
     dependencies:
@@ -11777,10 +10882,6 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  widest-line@5.0.0:
-    dependencies:
-      string-width: 7.2.0
-
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -11801,26 +10902,29 @@ snapshots:
 
   y18n@5.0.8: {}
 
-  yaml-language-server@1.15.0:
+  yaml-language-server@1.20.0:
     dependencies:
+      "@vscode/l10n": 0.0.18
       ajv: 8.17.1
-      lodash: 4.17.21
+      ajv-draft-04: 1.0.0(ajv@8.17.1)
+      prettier: 3.8.3
       request-light: 0.5.8
       vscode-json-languageservice: 4.1.8
-      vscode-languageserver: 7.0.0
+      vscode-languageserver: 9.0.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.17.5
-      vscode-nls: 5.2.0
       vscode-uri: 3.1.0
-      yaml: 2.2.2
-    optionalDependencies:
-      prettier: 2.8.7
+      yaml: 2.7.1
 
-  yaml@2.2.2: {}
+  yaml@2.7.1: {}
 
   yaml@2.8.1: {}
 
+  yaml@2.8.3: {}
+
   yargs-parser@21.1.1: {}
+
+  yargs-parser@22.0.0: {}
 
   yargs@17.7.2:
     dependencies:
@@ -11839,23 +10943,8 @@ snapshots:
 
   yocto-queue@1.2.1: {}
 
-  yocto-spinner@0.2.3:
-    dependencies:
-      yoctocolors: 2.1.2
-
-  yoctocolors@2.1.2: {}
-
   zimmerframe@1.1.2: {}
 
-  zod-to-json-schema@3.25.2(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
-
-  zod-to-ts@1.2.0(typescript@5.9.2)(zod@3.25.76):
-    dependencies:
-      typescript: 5.9.2
-      zod: 3.25.76
-
-  zod@3.25.76: {}
+  zod@4.3.6: {}
 
   zwitch@2.0.4: {}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,10 +1,11 @@
+import { docsLoader } from "@astrojs/starlight/loaders";
 import { docsSchema } from "@astrojs/starlight/schema";
 import { defineCollection } from "astro:content";
 import { autoSidebarLoader } from "starlight-auto-sidebar/loader";
 import { autoSidebarSchema } from "starlight-auto-sidebar/schema";
 
 export const collections = {
-  docs: defineCollection({ schema: docsSchema() }),
+  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
   autoSidebar: defineCollection({
     loader: autoSidebarLoader(),
     schema: autoSidebarSchema(),

--- a/src/content/docs/highlights/v0.30.md
+++ b/src/content/docs/highlights/v0.30.md
@@ -12,10 +12,10 @@ In this release we've [modularized the crates](#modularization), added full
 improvements — all with better [backend](#backend) flexibility and styling improvements.
 
 See the [changelog](https://github.com/ratatui/ratatui/blob/main/CHANGELOG.md) for the full list of
-changes. See the breaking changes for this release
-[here](https://github.com/ratatui/ratatui/blob/main/BREAKING-CHANGES.md).
+changes. See the
+[breaking changes for this release](https://github.com/ratatui/ratatui/blob/main/BREAKING-CHANGES.md).
 
-## Modularization 🧩
+## Modularization 🧩 {#modularization}
 
 Starting with Ratatui 0.30.0, the codebase was reorganized from a single monolithic crate into a
 modular workspace consisting of multiple specialized crates. This architectural decision was made to
@@ -24,7 +24,7 @@ provide better API stability for third-party widget libraries.
 
 Here is the new structure of the Ratatui workspace:
 
-```
+```text
 ratatui
 ├── ratatui-core
 ├── ratatui-widgets (depends on ratatui-core)
@@ -70,7 +70,7 @@ libraries.
 
 ## `no_std` Support 🛠️ {#no_std-support}
 
-_we are so embedded_
+_We are so embedded._
 
 Ratatui now supports compilation for `no_std` targets! 🎉
 
@@ -155,7 +155,7 @@ impl App {
 ratatui::run(|terminal| App::new().run(terminal))?;
 ```
 
-## Widgets 🧩
+## Widgets 🧩 {#widgets}
 
 ### BarChart 📊
 
@@ -418,7 +418,7 @@ are added.
 
 ## Text 📝
 
-#### `AddAssign` for `Text`
+### `AddAssign` for `Text`
 
 `Text` now implements `AddAssign` trait.
 
@@ -432,7 +432,7 @@ text += Text::from("line 2");
 Style and alignment applied to the second text is ignored (though styles and alignment of lines and
 spans are copied).
 
-#### Other improvements
+### Text improvements
 
 - Don't render [control characters](https://en.wikipedia.org/wiki/Unicode_control_characters) for
   `Span`
@@ -442,7 +442,7 @@ spans are copied).
 
 ## Styling 🎨
 
-#### Conversions from `anstyle`
+### Conversions from `anstyle`
 
 Support conversions from [anstyle](https://crates.io/crates/anstyle) styles (gated behind `anstyle`
 feature):
@@ -452,7 +452,7 @@ let anstyle_color = anstyle::Ansi256Color(42);
 let color = Color::from(anstyle_color);
 ```
 
-#### Conversions from tuples
+### Conversions from tuples
 
 Added generic color conversion methods from tuples:
 
@@ -463,7 +463,7 @@ Color::from([255, 0, 0, 255]);
 Color::from((255, 0, 0, 255));
 ```
 
-#### Conversions from primitives
+### Conversions from primitives
 
 Implement `Styled` for primitives such as `u8`, `i32`, `f64`, `Cow<'a, str>`, etc.
 
@@ -472,7 +472,7 @@ let s = Cow::Borrowed("a");
 assert_eq!(s.red(), "a".red());
 ```
 
-#### Implement stylize methods directly on `Style`
+### Implement stylize methods directly on `Style`
 
 This makes it possible to create constants using the shorthand methods.
 
@@ -483,9 +483,9 @@ const MY_STYLE: Style = Style::new().blue().on_black();
 This is a
 [breaking change](https://github.com/ratatui/ratatui/blob/main/BREAKING-CHANGES.md#style-no-longer-implements-styled-1572).
 
-## Layout 📐
+## Layout 📐 {#layout}
 
-#### Ergonomic layouting methods
+### Ergonomic layouting methods
 
 We introduced new methods for `Rect` that simplify the process of splitting a `Rect` into sub-rects
 according to a given `Layout`.
@@ -519,7 +519,7 @@ let [top, main] = layout.try_areas(area)?;
 let areas_vec = area.layout_vec(&layout);
 ```
 
-#### Helper methods for centering `Rect`s
+### Helper methods for centering `Rect`s
 
 For centering:
 
@@ -541,13 +541,13 @@ Horizontally centering:
 let area = frame.area().centered_horizontally(Constraint::Length(3));
 ```
 
-#### Add `Rect::outer` method
+### Add `Rect::outer` method
 
 This creates a new `Rect` outside the current one, with the given margin applied on each side.
 
 Also added `VerticalAlignment` type.
 
-#### Introduce `Flex::SpaceEvenly`
+### Introduce `Flex::SpaceEvenly`
 
 Old `Flex::SpaceAround` behavior is available by using `Flex::SpaceEvenly` and new
 `Flex::SpaceAround` now distributes space evenly around each element except the middle spacers are
@@ -573,7 +573,7 @@ The following is a screenshot in action:
 src="https://github.com/user-attachments/assets/2c7cd797-27bd-4242-a824-4565d369227b"
 />
 
-#### Other improvements
+### Layout improvements
 
 - Rename `Alignment` to `HorizontalAlignment` to better reflect its purpose
 
@@ -591,7 +591,7 @@ src="https://github.com/user-attachments/assets/2c7cd797-27bd-4242-a824-4565d369
 
 ## Backend 🖥️ {#backend}
 
-#### Backend conversion traits
+### Backend conversion traits
 
 The `From` implementations for backend types are now replaced with more specific traits.
 
@@ -618,7 +618,7 @@ See
 [this breaking changes entry](https://github.com/ratatui/ratatui/blob/main/BREAKING-CHANGES.md#the-from-impls-for-backend-types-are-now-replaced-with-more-specific-traits-1464)
 for more information.
 
-#### Associated `Error` type and required `clear_region` method
+### Associated `Error` type and required `clear_region` method
 
 Custom `Backend` implementations now require an associated `Error` type and `clear_region` method.
 
@@ -637,7 +637,7 @@ See
 [this breaking changes entry](https://github.com/ratatui/ratatui/blob/main/BREAKING-CHANGES.md#backend-now-requires-an-associated-error-type-and-clear_region-method-1778)
 for more information and other workarounds.
 
-#### Support for multiple crossterm versions
+### Support for multiple crossterm versions
 
 We now have individual feature flags for different crossterm versions. By default, the latest
 version is enabled. If multiple features are enabled, we choose the latest version.
@@ -652,13 +652,13 @@ If your dependency graph ends up with multiple Crossterm majors, see
 [Crossterm version compatibility](/concepts/backends/#crossterm-version-compatibility) for the risks
 and mitigations.
 
-#### Other improvements
+### Backend improvements
 
 `TestBackend` now uses `core::convert::Infallible` for error handling instead of `std::io::Error`
 
 ## Traits 🔧
 
-#### `State` associated types are now `?Sized`
+### `State` associated types are now `?Sized`
 
 `StatefulWidget::State` and `StatefulWidgetRef::State` are now `?Sized`.
 
@@ -666,7 +666,7 @@ This allows implementations of the traits to use unsized types for the State ass
 is turn is useful when doing things like boxing different stateful widget types with State which
 implements `Any`, are slices or any other dynamically sized type.
 
-#### Changes to `WidgetRef` trait
+### Changes to `WidgetRef` trait
 
 `WidgetRef` no longer has a blanket implementation of `Widget`.
 
@@ -684,7 +684,7 @@ instead be a blanket implementation of `WidgetRef` for all `&W` where `W: Widget
 Any widgets that previously implemented `WidgetRef` directly should now instead implement `Widget`
 for a reference to the type.
 
-#### New `FrameExt` trait
+### New `FrameExt` trait
 
 To call `Frame::render_widget_ref()` or `Frame::render_stateful_widget_ref()` you now need to import
 the `FrameExt` trait and enable the `unstable-widget-ref` feature.
@@ -734,18 +734,18 @@ If you want a custom badge, Ratatui logo is also available on [shields.io](https
 Some examples are:
 
 ```md
-![](https://img.shields.io/badge/Ratatui-000?logo=ratatui&logoColor=fff)
-![](https://img.shields.io/badge/Ratatui-fff?logo=ratatui&logoColor=000)
-![](https://img.shields.io/badge/Built_With-Ratatui-000?logo=ratatui&logoColor=fff&labelColor=000&color=fff)
-![](https://img.shields.io/badge/Ratatui-000?logo=ratatui&logoColor=fff&style=flat-square)
-![](https://img.shields.io/badge/Ratatui-000?logo=ratatui&logoColor=fff&style=for-the-badge)
+![Ratatui badge](https://img.shields.io/badge/Ratatui-000?logo=ratatui&logoColor=fff)
+![Ratatui badge with light background](https://img.shields.io/badge/Ratatui-fff?logo=ratatui&logoColor=000)
+![Built with Ratatui badge](https://img.shields.io/badge/Built_With-Ratatui-000?logo=ratatui&logoColor=fff&labelColor=000&color=fff)
+![Flat square Ratatui badge](https://img.shields.io/badge/Ratatui-000?logo=ratatui&logoColor=fff&style=flat-square)
+![For the badge style Ratatui badge](https://img.shields.io/badge/Ratatui-000?logo=ratatui&logoColor=fff&style=for-the-badge)
 ```
 
-![](https://img.shields.io/badge/Ratatui-000?logo=ratatui&logoColor=fff)
-![](https://img.shields.io/badge/Ratatui-fff?logo=ratatui&logoColor=000)
-![](https://img.shields.io/badge/Built_With-Ratatui-000?logo=ratatui&logoColor=fff&labelColor=000&color=fff)
-![](https://img.shields.io/badge/Ratatui-000?logo=ratatui&logoColor=fff&style=flat-square)
-![](https://img.shields.io/badge/Ratatui-000?logo=ratatui&logoColor=fff&style=for-the-badge)
+![Ratatui badge](https://img.shields.io/badge/Ratatui-000?logo=ratatui&logoColor=fff)
+![Ratatui badge with light background](https://img.shields.io/badge/Ratatui-fff?logo=ratatui&logoColor=000)
+![Built with Ratatui badge](https://img.shields.io/badge/Built_With-Ratatui-000?logo=ratatui&logoColor=fff&labelColor=000&color=fff)
+![Flat square Ratatui badge](https://img.shields.io/badge/Ratatui-000?logo=ratatui&logoColor=fff&style=flat-square)
+![For the badge style Ratatui badge](https://img.shields.io/badge/Ratatui-000?logo=ratatui&logoColor=fff&style=for-the-badge)
 
 ## Other 💼
 

--- a/src/plugins/collapsible-frames.mjs
+++ b/src/plugins/collapsible-frames.mjs
@@ -10,8 +10,8 @@ export function collapsibleFrames() {
     baseStyles: `
       .collapsible-frame {
         & summary {
-	      display:none;
           cursor: pointer;
+          list-style: none;
           &::marker {
             display: inline-block;
             content: "";


### PR DESCRIPTION
## Summary

Updates the website's Astro/Starlight stack while keeping the change focused on the framework upgrade path:

- upgrades Astro to 6.x and Starlight to 0.38.x
- upgrades the directly related integrations and peers, including Starlight Tailwind, Starlight auto-sidebar, Starlight links validator, Shiki, Sharp, Tailwind, and Vitest
- keeps Vite on the Astro-supported 7.x line via the existing pnpm override instead of jumping to Vite 8
- moves Starlight content collections to the Astro 6 `src/content.config.ts` + `docsLoader()` shape
- fixes stricter link/heading validation in the v0.30 highlight page
- keeps the local collapsible code-frame plugin clickable after the Expressive Code/Starlight update

## Why these versions?

Astro 6 expects Node 22.12+ and uses Vite 7. Since the previous setup PR already moved the repo to Node 24 and pnpm, this change updates the framework stack without changing the runtime/tooling model again. The related Starlight packages were updated together because their latest versions have matching peer dependency expectations around Astro 6 and Starlight 0.38.

I did not include unrelated major updates such as TypeScript 6, Marked 18, TOML 4, tree-sitter 0.25, or Vite 8. Those are better handled separately because they can affect compiler behavior, markdown parsing, TOML parsing, native/parser dependencies, or bundler behavior outside the Astro 6 migration itself.

## Notes for reviewers

A few changes may look broader than a normal dependency bump:

- `src/content/config.ts` moved to `src/content.config.ts` because Astro/Starlight's current content collection setup uses that root-level config file and `docsLoader()`.
- `src/content/docs/highlights/v0.30.md` changes are mostly heading IDs/levels and markdown cleanup needed by the newer links validator and markdown tooling.
- `src/plugins/collapsible-frames.mjs` stopped hiding the `<summary>` element. After the upgrade, that made collapsible tutorial code frames invisible to the browser and non-clickable.
- `pnpm-lock.yaml` has a large diff because the Astro/Starlight dependency graph moved from Astro 5/Vite 6 to Astro 6/Vite 7.

## Verification

- `mise exec -- corepack pnpm format:check`
- `mise exec -- corepack pnpm test -- --run`
- `mise exec -- corepack pnpm exec markdownlint-cli2 src/content/docs/highlights/v0.30.md`
- `mise run build`
- Playwright smoke checks against `astro dev` on `127.0.0.1:4321`
- Playwright smoke checks against `astro preview` on `127.0.0.1:4322`, including production Pagefind search for “cloudflare”

The build still reports the existing Astro check hints about unused variables, `frameborder`, and inline script behavior; there are no check errors.
