### PR TITLE
Add "System" theme option on main page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -60,6 +60,7 @@ export default defineConfig({
       components: {
         Head: "./src/components/Head.astro",
         Header: "./src/components/Header.astro",
+        ThemeSelect: "./src/components/ThemeSwitch.astro",
       },
       plugins: [
         starlightLinksValidator({

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,9 +1,10 @@
 ---
 import Search from "@astrojs/starlight/components/Search.astro";
 import SiteTitle from "@astrojs/starlight/components/SiteTitle.astro";
-// virtual: resolves the ThemeSelect override from astro.config.mjs; the direct
-// @astrojs/starlight import would always render Starlight's built-in dropdown.
-import ThemeSelect from "virtual:starlight/components/ThemeSelect";
+// Import the override directly: `@astrojs/starlight/components/ThemeSelect.astro`
+// would always render Starlight's built-in dropdown, and the `virtual:` specifier
+// has no type declarations.
+import ThemeSelect from "@components/ThemeSwitch.astro";
 import SocialIcons from "@components/SocialIcons.astro";
 import LanguageSelect from "@astrojs/starlight/components/LanguageSelect.astro";
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,7 +1,9 @@
 ---
 import Search from "@astrojs/starlight/components/Search.astro";
 import SiteTitle from "@astrojs/starlight/components/SiteTitle.astro";
-import ThemeSelect from "@astrojs/starlight/components/ThemeSelect.astro";
+// virtual: resolves the ThemeSelect override from astro.config.mjs; the direct
+// @astrojs/starlight import would always render Starlight's built-in dropdown.
+import ThemeSelect from "virtual:starlight/components/ThemeSelect";
 import SocialIcons from "@components/SocialIcons.astro";
 import LanguageSelect from "@astrojs/starlight/components/LanguageSelect.astro";
 

--- a/src/components/ThemeSwitch.astro
+++ b/src/components/ThemeSwitch.astro
@@ -79,12 +79,12 @@
 
   // Clicking cycles through every mode rather than flipping between two.
   const nextTheme = (theme: Theme): Theme =>
-    theme === "light" ? "dark" : theme === "dark" ? "auto" : "light";
+    theme === "dark" ? "light" : theme === "light" ? "auto" : "dark";
 
   const labels: Record<Theme, string> = {
-    light: "Light theme, switch to dark",
-    dark: "Dark theme, switch to system",
-    auto: "System theme, switch to light",
+    dark: "Dark theme, switch to light",
+    light: "Light theme, switch to system",
+    auto: "System theme, switch to dark",
   };
 
   // Every toggle on the page has to reflect a change made through any of them.

--- a/src/components/ThemeSwitch.astro
+++ b/src/components/ThemeSwitch.astro
@@ -6,7 +6,7 @@
   >
     <!-- Sun Icon -->
     <svg
-      class="sun-icon absolute inset-0 m-auto h-5 w-5 scale-0 rotate-90 transition-all duration-300 dark:scale-100 dark:rotate-0"
+      class="theme-icon sun-icon absolute inset-0 m-auto h-5 w-5 scale-0 rotate-90 transition-all duration-300"
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
@@ -21,7 +21,7 @@
 
     <!-- Moon Icon -->
     <svg
-      class="moon-icon absolute inset-0 m-auto h-5 w-5 scale-100 rotate-0 transition-all duration-300 dark:scale-0 dark:rotate-90"
+      class="theme-icon moon-icon absolute inset-0 m-auto h-5 w-5 scale-0 rotate-90 transition-all duration-300"
       fill="currentColor"
       viewBox="0 0 24 24"
     >
@@ -29,8 +29,33 @@
         d="M21.64 13a1 1 0 00-1.05-.14 8.05 8.05 0 01-3.37.73 8.15 8.15 0 01-8.14-8.1 8.59 8.59 0 01.25-2A1 1 0 008 2.36a10.14 10.14 0 1014 11.69 1 1 0 00-.36-1.05zm-9.5 6.69A8.14 8.14 0 017.08 5.22v.27a10.15 10.15 0 0010.14 10.14 9.79 9.79 0 002.1-.22 8.11 8.11 0 01-7.18 4.32z"
       ></path>
     </svg>
+
+    <!-- Monitor Icon (system) -->
+    <svg
+      class="theme-icon system-icon absolute inset-0 m-auto h-5 w-5 scale-0 rotate-90 transition-all duration-300"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <rect x="2" y="4" width="20" height="13" rx="2"></rect>
+      <path d="M8 21h8m-4-4v4"></path>
+    </svg>
   </button>
 </starlight-theme-toggle>
+
+<style>
+  /* Icons are hidden until the element hydrates and sets `data-theme`, so a
+     stale icon never flashes before the stored preference is known. */
+  starlight-theme-toggle[data-theme="light"] .moon-icon,
+  starlight-theme-toggle[data-theme="dark"] .sun-icon,
+  starlight-theme-toggle[data-theme="auto"] .system-icon {
+    rotate: 0deg;
+    scale: 1;
+  }
+</style>
 
 <script>
   type Theme = "auto" | "dark" | "light";
@@ -52,6 +77,19 @@
   const getPreferredColorScheme = (): Theme =>
     matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
 
+  // Clicking cycles through every mode rather than flipping between two.
+  const nextTheme = (theme: Theme): Theme =>
+    theme === "light" ? "dark" : theme === "dark" ? "auto" : "light";
+
+  const labels: Record<Theme, string> = {
+    light: "Light theme, switch to dark",
+    dark: "Dark theme, switch to system",
+    auto: "System theme, switch to light",
+  };
+
+  // Every toggle on the page has to reflect a change made through any of them.
+  const toggles = new Set<StarlightThemeToggle>();
+
   function onThemeChange(theme: Theme): void {
     const resolvedTheme = theme === "auto" ? getPreferredColorScheme() : theme;
 
@@ -63,6 +101,7 @@
 
     document.documentElement.dataset.theme = resolvedTheme;
     storeTheme(theme);
+    for (const toggle of toggles) toggle.render(theme);
   }
 
   matchMedia(`(prefers-color-scheme: light)`).addEventListener("change", () => {
@@ -70,15 +109,27 @@
   });
 
   class StarlightThemeToggle extends HTMLElement {
-    constructor() {
-      super();
-      onThemeChange(loadTheme());
+    // Delegated from the host so the handler works no matter when the button
+    // is parsed, and so it can be detached again on disconnect.
+    #onClick = (event: MouseEvent): void => {
+      if (!(event.target as Element | null)?.closest("button")) return;
+      onThemeChange(nextTheme(loadTheme()));
+    };
 
-      this.querySelector("button")?.addEventListener("click", () => {
-        const currentTheme = loadTheme();
-        const newTheme: Theme = currentTheme === "light" ? "dark" : "light";
-        onThemeChange(newTheme);
-      });
+    connectedCallback(): void {
+      toggles.add(this);
+      this.addEventListener("click", this.#onClick);
+      onThemeChange(loadTheme());
+    }
+
+    disconnectedCallback(): void {
+      toggles.delete(this);
+      this.removeEventListener("click", this.#onClick);
+    }
+
+    render(theme: Theme): void {
+      this.dataset.theme = theme;
+      this.querySelector("button")?.setAttribute("aria-label", labels[theme]);
     }
   }
   customElements.define("starlight-theme-toggle", StarlightThemeToggle);


### PR DESCRIPTION
## Describe

The main page only have `Light` and `Dark` themes right now. It would be nice to have a System option so the theme automatically matches the user's OS setting.

## Before:
N/A

## After:
https://github.com/user-attachments/assets/83593892-d301-4e8a-b47c-63854ec3ce42

