### PR TITLE
Fix copying YouTube link to clipboard

### DIFF
--- a/src/components/ShowcaseCard.astro
+++ b/src/components/ShowcaseCard.astro
@@ -58,7 +58,8 @@ try {
             class="h-full w-full"
             src={media}
             title="YouTube video player"
-            allow="autoplay;"
+            allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"
+            referrerpolicy="strict-origin-when-cross-origin"
           />
         ) : (
           <img class="h-full w-full object-cover" src={media} alt={alt} />

--- a/src/components/TutorialVideo.astro
+++ b/src/components/TutorialVideo.astro
@@ -28,6 +28,7 @@ const { title, youtubeId, description } = Astro.props;
       src={`https://www.youtube-nocookie.com/embed/5Lu9MSgmTBc?autoplay=0&loop=1&playlist=${youtubeId}&mute=0&controls=0&modestbranding=0&rel=0&showinfo=0`}
       title="YouTube video player"
       frameborder="0"
-      allow="autoplay;"></iframe>
+      allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"
+      referrerpolicy="strict-origin-when-cross-origin"></iframe>
   </a>
 </div>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->

<!--
If this PR adds or updates a showcase app or third-party widget, please open a showcase submission
issue first so we can discuss fit and presentation before review:

https://github.com/ratatui/ratatui-website/issues/new?template=showcase-submission.yml

Also read:
- https://ratatui.rs/recipes/apps/submitting-to-the-showcase/
- https://ratatui.rs/recipes/apps/release-your-app/

When you open the PR, link back to the showcase submission issue.
-->

## Description: 
Clicking the share/copy-link button in an embedded YouTube player showed "Unable to copy link to clipboard".


Before:

https://github.com/user-attachments/assets/2aa1087e-89d3-44ce-8752-8b52138ec0fa

After:

https://github.com/user-attachments/assets/e9f84097-eb0e-4e4d-bd62-548d421745f9

