### PR TITLE
Fix copying YouTube video link to clipboard on tutorials/videos/ page

### DIFF
--- a/src/components/youtube-card.astro
+++ b/src/components/youtube-card.astro
@@ -35,7 +35,7 @@ let description_markdown = marked.parse(description || "");
     const createBasicIframe = proto.createBasicIframe;
     proto.createBasicIframe = function () {
       const iframe = createBasicIframe.call(this);
-      iframe.allow = `${iframe.allow}; clipboard-write; web-share`;
+      iframe.allow = `${iframe.allow}; autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share`;
       return iframe;
     };
   });

--- a/src/components/youtube-card.astro
+++ b/src/components/youtube-card.astro
@@ -21,13 +21,15 @@ let description_markdown = marked.parse(description || "");
   </div>
 </MediaCard>
 
-{/*
+{
+  /*
   lite-youtube-embed hardcodes the iframe's `allow` list and gives us no way to
   configure it, which leaves out `clipboard-write` -- so the player's share button
   fails with "Unable to copy link to clipboard" in Chromium.
   Wrap createBasicIframe() to append the missing permissions; it returns the iframe
   before it is inserted, which is the last point where `allow` still takes effect.
-*/}
+*/
+}
 <script>
   customElements.whenDefined("lite-youtube").then(() => {
     const proto = customElements.get("lite-youtube")?.prototype as any;

--- a/src/components/youtube-card.astro
+++ b/src/components/youtube-card.astro
@@ -21,6 +21,26 @@ let description_markdown = marked.parse(description || "");
   </div>
 </MediaCard>
 
+{/*
+  lite-youtube-embed hardcodes the iframe's `allow` list and gives us no way to
+  configure it, which leaves out `clipboard-write` -- so the player's share button
+  fails with "Unable to copy link to clipboard" in Chromium.
+  Wrap createBasicIframe() to append the missing permissions; it returns the iframe
+  before it is inserted, which is the last point where `allow` still takes effect.
+*/}
+<script>
+  customElements.whenDefined("lite-youtube").then(() => {
+    const proto = customElements.get("lite-youtube")?.prototype as any;
+    if (!proto?.createBasicIframe) return;
+    const createBasicIframe = proto.createBasicIframe;
+    proto.createBasicIframe = function () {
+      const iframe = createBasicIframe.call(this);
+      iframe.allow = `${iframe.allow}; clipboard-write; web-share`;
+      return iframe;
+    };
+  });
+</script>
+
 <style>
   .meta {
     padding: 1rem;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->

<!--
If this PR adds or updates a showcase app or third-party widget, please open a showcase submission
issue first so we can discuss fit and presentation before review:

https://github.com/ratatui/ratatui-website/issues/new?template=showcase-submission.yml

Also read:
- https://ratatui.rs/recipes/apps/submitting-to-the-showcase/
- https://ratatui.rs/recipes/apps/release-your-app/

When you open the PR, link back to the showcase submission issue.
-->
## Description:

Clicking the share/copy-link button in an embedded YouTube player showed "Unable to copy link to clipboard".

Before:

https://github.com/user-attachments/assets/51ceabaa-26e2-4f4c-9ab5-cdeedd13e232

After:

https://github.com/user-attachments/assets/4fcffb0a-4f54-4ff5-ae69-6a02ed1a95b8

