### PR TITLE
docs(contributing): fix broken documentation link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,4 +86,4 @@ the showcase yet, consider sharing it on Awesome Ratatui, the forum, or Discord 
 
 ## License
 
-By contributing, you agree that your contributions are licensed under the [MIT license](LICENSE).
+By contributing, you agree that your contributions are licensed under the [MIT license](LICENSE.md).


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->

<!--
If this PR adds or updates a showcase app or third-party widget, please open a showcase submission
issue first so we can discuss fit and presentation before review:

https://github.com/ratatui/ratatui-website/issues/new?template=showcase-submission.yml

Also read:
- https://ratatui.rs/recipes/apps/submitting-to-the-showcase/
- https://ratatui.rs/recipes/apps/release-your-app/

When you open the PR, link back to the showcase submission issue.
-->
## Summary: 

Fixed the broken MIT License link in `CONTRIBUTING.md` by updating it from `LICENSE` to `LICENSE.md`.
