### PR TITLE
Harden build-time GitHub stats fetching

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,17 @@ contain a diagram, so local and Cloudflare builds do not require Playwright or a
 Cloudflare Workers Builds should build the site with `pnpm build`. If the Cloudflare project does
 not read `.node-version`, set its Node.js version to `24`.
 
+Define `GITHUB_TOKEN` under the Workers Builds
+[build variables and secrets](https://developers.cloudflare.com/workers/ci-cd/builds/configuration/)
+as an encrypted secret. Use a dedicated
+[fine-grained GitHub personal access token](https://docs.github.com/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+with access limited to public repositories and read-only repository metadata. The build uses it only
+to fetch star and fork counts; authenticating avoids GitHub's lower unauthenticated API rate limit.
+
+This build secret is separate from both the Cloudflare API token that authorizes Workers Builds to
+upload and deploy the site and any secrets bound to the deployed Worker at runtime. Do not configure
+`GITHUB_TOKEN` as a runtime Worker secret.
+
 ## Assets
 
 `.png`, `.gif`, `.svg`, `.webp` and `.xcf` files are tracked by Git LFS. Add new images with LFS to

--- a/src/utils/stats.test.ts
+++ b/src/utils/stats.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getGitHubStats } from "./stats";
+
+describe("getGitHubStats", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("times out, retries once, and falls back without waiting indefinitely", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const request = vi.fn(
+      (_owner: string, _repo: string, _signal: AbortSignal) => new Promise<never>(() => {}),
+    );
+
+    const stats = getGitHubStats("ratatui", "ratatui", {
+      request,
+      timeoutMs: 100,
+      retryDelayMs: 25,
+    });
+    await vi.advanceTimersByTimeAsync(225);
+
+    await expect(stats).resolves.toEqual({ stars: 13418, forks: 500 });
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request.mock.calls.every(([, , signal]) => signal.aborted)).toBe(true);
+    expect(warn).toHaveBeenLastCalledWith(
+      expect.stringMatching(/fell back after \d+ms.*timed out/),
+    );
+  });
+
+  it("retries a transient network failure with backoff and then succeeds", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce({ stars: 42, forks: 7 });
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      getGitHubStats("owner", "repo", { request, retryDelayMs: 250, sleep }),
+    ).resolves.toEqual({ stars: 42, forks: 7 });
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(250);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("owner/repo: retrying"));
+  });
+
+  it.each([401, 403, 429])("does not retry HTTP %s failures", async (status) => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const request = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("request failed"), { status }));
+    const sleep = vi.fn();
+
+    await expect(getGitHubStats("owner", "repo", { request, sleep })).resolves.toEqual({
+      stars: 13418,
+      forks: 500,
+    });
+    expect(request).toHaveBeenCalledOnce();
+    expect(sleep).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringMatching(new RegExp(`owner/repo: fell back after \\d+ms \\(HTTP ${status}\\)`)),
+    );
+  });
+});

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -6,38 +6,154 @@ import type { CratesIoResponse, CratesIoReverseDepsResponse, GitHubRepo } from "
 const token = import.meta.env.GITHUB_TOKEN ?? process.env.GITHUB_TOKEN;
 const octokit = new Octokit({
   auth: token,
+  // Keep retries and rate-limit waits inside our bounded, logged policy below.
+  retry: { enabled: false },
+  throttle: { enabled: false },
 });
 
-export async function getGitHubStats(owner: string, repo: string): Promise<GitHubRepo> {
-  const fallback = { stars: 13418, forks: 500 };
-  if (import.meta.env.DEV) {
-    return fallback;
+const GITHUB_STATS_TIMEOUT_MS = 5_000;
+const GITHUB_STATS_RETRY_DELAY_MS = 500;
+const GITHUB_STATS_ATTEMPTS = 2;
+
+type GitHubStatsRequest = (owner: string, repo: string, signal: AbortSignal) => Promise<GitHubRepo>;
+
+/** Dependency overrides for deterministic timeout and retry tests. */
+interface GitHubStatsOptions {
+  request?: GitHubStatsRequest;
+  timeoutMs?: number;
+  retryDelayMs?: number;
+  sleep?: (milliseconds: number) => Promise<void>;
+}
+
+class InvalidGitHubResponseError extends Error {}
+
+class GitHubStatsTimeoutError extends Error {}
+
+async function requestGitHubStats(
+  owner: string,
+  repo: string,
+  signal: AbortSignal,
+): Promise<GitHubRepo> {
+  const { data } = await octokit.rest.repos.get({
+    owner,
+    repo,
+    request: { signal },
+  });
+
+  if (typeof data.stargazers_count !== "number" || typeof data.forks_count !== "number") {
+    throw new InvalidGitHubResponseError("invalid response structure");
   }
+
+  return {
+    stars: data.stargazers_count,
+    forks: data.forks_count,
+  };
+}
+
+/** Runs one request attempt and aborts its underlying fetch when the deadline expires. */
+async function withTimeout<T>(
+  request: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      controller.abort();
+      reject(new GitHubStatsTimeoutError(`timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
 
   try {
-    // Use Octokit's rest API for repo info
-    const { data } = await octokit.rest.repos.get({
-      owner,
-      repo,
-    });
+    return await Promise.race([request(controller.signal), timeout]);
+  } finally {
+    clearTimeout(timeoutId!);
+  }
+}
 
-    if (typeof data.stargazers_count !== "number" || typeof data.forks_count !== "number") {
-      console.error("Invalid GitHub response structure:", {
-        stargazers_count: data.stargazers_count,
-        forks_count: data.forks_count,
-      });
-      throw new Error("Invalid response structure from GitHub API");
-    }
+function errorStatus(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null || !("status" in error)) {
+    return undefined;
+  }
+  return typeof error.status === "number" ? error.status : undefined;
+}
 
-    return {
-      stars: data.stargazers_count,
-      forks: data.forks_count,
-    };
-  } catch (error) {
-    console.error("Failed to fetch GitHub stats (Octokit):", error);
-    // Fallback values
+function describeGitHubError(error: unknown): string {
+  const status = errorStatus(error);
+  if (status !== undefined) {
+    return `HTTP ${status}`;
+  }
+  return error instanceof Error ? error.message : "unknown error";
+}
+
+/** Retries network failures, timeouts, request timeouts, and selected transient server errors. */
+function shouldRetryGitHubError(error: unknown): boolean {
+  if (error instanceof InvalidGitHubResponseError) {
+    return false;
+  }
+
+  const status = errorStatus(error);
+  if (status === undefined) {
+    return true;
+  }
+  return status === 408 || status === 500 || status === 502 || status === 503 || status === 504;
+}
+
+/**
+ * Fetches star and fork counts for a repository without making site availability depend on GitHub.
+ *
+ * Production requests have a five-second deadline and at most one retry after a short backoff.
+ * Authentication, permission, rate-limit, malformed-response, and other non-transient HTTP failures
+ * are not retried. Every attempt and outcome is logged with the repository identity; if all eligible
+ * attempts fail, this function logs the fallback and returns stable fallback values instead of
+ * throwing.
+ */
+export async function getGitHubStats(
+  owner: string,
+  repo: string,
+  options: GitHubStatsOptions = {},
+): Promise<GitHubRepo> {
+  const fallback = { stars: 13418, forks: 500 };
+  if (import.meta.env.DEV && options.request === undefined) {
     return fallback;
   }
+
+  const identity = `${owner}/${repo}`;
+  const request = options.request ?? requestGitHubStats;
+  const timeoutMs = options.timeoutMs ?? GITHUB_STATS_TIMEOUT_MS;
+  const retryDelayMs = options.retryDelayMs ?? GITHUB_STATS_RETRY_DELAY_MS;
+  const sleep =
+    options.sleep ??
+    ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+  const startedAt = Date.now();
+
+  for (let attempt = 1; attempt <= GITHUB_STATS_ATTEMPTS; attempt += 1) {
+    console.info(
+      `[github-stats] ${identity}: pending (attempt ${attempt}/${GITHUB_STATS_ATTEMPTS}, timeout ${timeoutMs}ms)`,
+    );
+
+    try {
+      const stats = await withTimeout((signal) => request(owner, repo, signal), timeoutMs);
+      console.info(`[github-stats] ${identity}: succeeded in ${Date.now() - startedAt}ms`);
+      return stats;
+    } catch (error) {
+      const elapsed = Date.now() - startedAt;
+      const retry = attempt < GITHUB_STATS_ATTEMPTS && shouldRetryGitHubError(error);
+      if (!retry) {
+        console.warn(
+          `[github-stats] ${identity}: fell back after ${elapsed}ms (${describeGitHubError(error)})`,
+        );
+        return fallback;
+      }
+
+      console.warn(
+        `[github-stats] ${identity}: retrying after ${elapsed}ms (${describeGitHubError(error)}; backoff ${retryDelayMs}ms)`,
+      );
+      await sleep(retryDelayMs);
+    }
+  }
+
+  return fallback;
 }
 
 export async function getCratesStats(): Promise<{ downloads: number }> {


### PR DESCRIPTION
## Summary

- bound build-time GitHub repository metadata requests with cancellation, one limited retry, and
  stable fallback values
- log pending, retry, success, and fallback outcomes with repository identities and elapsed time
- document the encrypted `GITHUB_TOKEN` build secret and distinguish it from Cloudflare deployment
  credentials and runtime secrets

Octokit's built-in retry and throttling policies are disabled so rate limits cannot introduce hidden,
multi-minute waits outside the site's bounded policy.

## Validation

- `pnpm test --run` (19 tests passed)
- `pnpm format:check`
- `pnpm exec markdownlint-cli2 CONTRIBUTING.md`
- `pnpm astro check` (no errors; four existing hints)
- `pnpm build` passed Astro checking, then stopped before static route generation because this local
  checkout has an unmaterialized Git LFS pointer for `src/assets/logo-light.png`

Follow-up to [the Workers migration issue](https://github.com/ratatui/ratatui-website/issues/880)
and [the Workers deployment migration](https://github.com/ratatui/ratatui-website/pull/1206).
