### PR TITLE
Clean up Astro build diagnostics

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ allowBuilds:
   sharp: true
   tree-sitter: true
   tree-sitter-rust: true
+  workerd: true

--- a/src/components/ScrambleCode.astro
+++ b/src/components/ScrambleCode.astro
@@ -28,7 +28,7 @@ const highlightedHtml = await codeToHtml(code, {
   <div class="highlighted-code" set:html={highlightedHtml} />
 </div>
 
-<script define:vars={{ code }}>
+<script define:vars={{ code }} is:inline>
   const initScramble = () => {
     const wrappers = document.querySelectorAll(".block-reveal-wrapper");
 

--- a/src/components/ScrambleText.astro
+++ b/src/components/ScrambleText.astro
@@ -29,7 +29,6 @@ interface Props {
 <script>
   class TextScrambler {
     private element: HTMLElement;
-    private originalText: string;
     private isScrambling: boolean = false;
     private isUnscrambling: boolean = false;
     private scrambleInterval: number | null = null;
@@ -40,7 +39,6 @@ interface Props {
 
     constructor(element: HTMLElement) {
       this.element = element;
-      this.originalText = element.getAttribute("data-original") || element.textContent || "";
 
       // Read image paths from data attributes
       const ratImg = element.getAttribute("data-rat") || "";

--- a/src/components/TutorialVideo.astro
+++ b/src/components/TutorialVideo.astro
@@ -24,10 +24,9 @@ const { title, youtubeId, description } = Astro.props;
 <div class="overflow-hidden p-6">
   <a href={`https://www.youtube.com/watch?v=${youtubeId}`} target="_blank">
     <iframe
-      class="h-full w-full"
+      class="h-full w-full border-0"
       src={`https://www.youtube-nocookie.com/embed/5Lu9MSgmTBc?autoplay=0&loop=1&playlist=${youtubeId}&mute=0&controls=0&modestbranding=0&rel=0&showinfo=0`}
       title="YouTube video player"
-      frameborder="0"
       allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"
       referrerpolicy="strict-origin-when-cross-origin"></iframe>
   </a>

--- a/src/utils/githubAuth.ts
+++ b/src/utils/githubAuth.ts
@@ -3,7 +3,7 @@ import { Octokit } from "octokit";
 const token = import.meta.env.GITHUB_TOKEN;
 const octokit = new Octokit({ auth: token });
 
-const issues = await octokit.request("GET /repos/{owner}/{repo}/issues", {
+await octokit.request("GET /repos/{owner}/{repo}/issues", {
   owner: "octocat",
   repo: "Spoon-Knife",
 });


### PR DESCRIPTION
## Summary

- approve Wrangler's `workerd` install script in the existing pnpm allowlist
- remove four Astro and TypeScript build diagnostics
- replace the deprecated iframe border attribute with CSS

The remaining large-chunk warning is Mermaid's already lazy-loaded renderer. The `docs → 404`
message is Starlight's optional custom-404 lookup before it generates the built-in page.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm format:check`
- `pnpm test --run`
- `pnpm exec astro check`
- `pnpm build`
