### PR TITLE
Allow tutorial video ID in typos

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -5,6 +5,9 @@ ratatui = "ratatui"
 iterm2 = "iTerm2"
 iterm = "iTerm2"
 
+[default.extend-identifiers]
+btqNDDuZ3cI = "btqNDDuZ3cI"
+
 [type.md]
 extend-ignore-re = [
   "\\[[[:xdigit:]]{7}\\]\\(https://github.com/ratatui/ratatui/commit/[[:xdigit:]]{40}\\)",


### PR DESCRIPTION
## Summary

- allow the immutable `btqNDDuZ3cI` YouTube ID as an exact typos identifier
- keep the exception narrow instead of allowing the `ND` substring globally

The current typos release otherwise interprets `ND` inside the video ID as a misspelling of
`AND`.

## Validation

- `typos .`
- `pnpm format:check`
